### PR TITLE
Use default names for measurement and field if they are not present

### DIFF
--- a/cmd/ifqld/main.go
+++ b/cmd/ifqld/main.go
@@ -239,6 +239,12 @@ func iterateResults(r execute.Result, f func(measurement, fieldName string, tags
 					}
 				}
 
+				if measurement == "" {
+					measurement = "measurement"
+				}
+				if fieldName == "" {
+					fieldName = "value"
+				}
 				f(measurement, fieldName, tags, value, time.Time())
 			}
 		})


### PR DESCRIPTION
Fixes #145 