### PR TITLE
Resource Management API

### DIFF
--- a/cmd/ifql/main.go
+++ b/cmd/ifql/main.go
@@ -97,8 +97,9 @@ func main() {
 
 	for _, r := range results {
 		blocks := r.Blocks()
-		err := blocks.Do(func(b execute.Block) {
+		err := blocks.Do(func(b execute.Block) error {
 			execute.NewFormatter(b, nil).WriteTo(os.Stdout)
+			return nil
 		})
 		if err != nil {
 			fmt.Println("Error:", err)

--- a/cmd/ifql/main.go
+++ b/cmd/ifql/main.go
@@ -73,7 +73,7 @@ func main() {
 	if len(hosts) == 0 {
 		hosts = defaultStorageHosts
 	}
-	results, querySpec, err := ifql.Query(
+	results, querySpec, err := ifql.ExecuteQuery(
 		ctx,
 		*queryStr,
 		&ifql.Options{

--- a/cmd/ifqld/main.go
+++ b/cmd/ifqld/main.go
@@ -38,9 +38,13 @@ type options struct {
 	IDFile            flags.Filename `long:"id-file" description:"Path to file that persists ifqld id" env:"ID_FILE" default:"./ifqld.id"`
 	ReportingDisabled bool           `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime,queryCount) once every 4hrs" env:"REPORTING_DISABLED"`
 	Verbose           bool           `short:"v" long:"verbose" description:"Log more verbose debugging output"`
+	ConcurrencyQuota  int            `short:"c" long:"concurrency-quota" description:"Maximum concurrency allowed" env:"CONCURRENCY_QUOTA"`
+	MemoryBytesQuota  int            `short:"m" long:"memory-quota" description:"Approximate maximum memory usage allowed in bytes" env:"MEMORY_BYTES_QUOTA"`
 }
 
-var opts options
+var opts = options{
+	ConcurrencyQuota: runtime.NumCPU() * 2,
+}
 var controller *ifql.Controller
 
 var functionCounter = prometheus.NewCounterVec(
@@ -76,7 +80,9 @@ func main() {
 		os.Exit(code)
 	}
 	c, err := ifql.NewController(ifql.Options{
-		Hosts: opts.Hosts,
+		Hosts:            opts.Hosts,
+		ConcurrencyQuota: opts.ConcurrencyQuota,
+		MemoryBytesQuota: opts.MemoryBytesQuota,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/functions/count.go
+++ b/functions/count.go
@@ -74,7 +74,7 @@ type CountAgg struct {
 }
 
 func createCountTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, ctx execute.Context) (execute.Transformation, execute.Dataset, error) {
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(CountAgg))
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(CountAgg), ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/data_test.go
+++ b/functions/data_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gonum/stat/distuv"
 	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/execute/executetest"
 )
 
 const (
@@ -32,8 +33,7 @@ func init() {
 	for i := range NormalData {
 		NormalData[i] = dist.Rand()
 	}
-
-	normalBlockBuilder := execute.NewColListBlockBuilder()
+	normalBlockBuilder := execute.NewColListBlockBuilder(executetest.UnlimitedAllocator)
 	normalBlockBuilder.SetBounds(execute.Bounds{
 		Start: execute.Time(time.Date(2016, 10, 10, 0, 0, 0, 0, time.UTC).UnixNano()),
 		Stop:  execute.Time(time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC).UnixNano()),
@@ -69,5 +69,5 @@ func init() {
 	normalBlockBuilder.SetCommonString(2, t1)
 	normalBlockBuilder.AppendStrings(3, t2)
 
-	NormalBlock = normalBlockBuilder.Block()
+	NormalBlock, _ = normalBlockBuilder.Block()
 }

--- a/functions/first.go
+++ b/functions/first.go
@@ -109,7 +109,7 @@ func createFirstTransformation(id execute.DatasetID, mode execute.AccumulationMo
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(FirstSelector), ps.UseRowTime)
+	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(FirstSelector), ps.UseRowTime, ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/join_test.go
+++ b/functions/join_test.go
@@ -738,7 +738,7 @@ func TestMergeJoin_Process(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			c := functions.NewMergeJoinCache(joinExpr)
+			c := functions.NewMergeJoinCache(joinExpr, executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 			jt := functions.NewMergeJoinTransformation(d, c, tc.spec)
 
@@ -752,10 +752,14 @@ func TestMergeJoin_Process(t *testing.T) {
 			}
 			for i := 0; i < l; i++ {
 				if i < len(tc.data0) {
-					jt.Process(parentID0, tc.data0[i])
+					if err := jt.Process(parentID0, tc.data0[i]); err != nil {
+						t.Fatal(err)
+					}
 				}
 				if i < len(tc.data1) {
-					jt.Process(parentID1, tc.data1[i])
+					if err := jt.Process(parentID1, tc.data1[i]); err != nil {
+						t.Fatal(err)
+					}
 				}
 			}
 

--- a/functions/last.go
+++ b/functions/last.go
@@ -110,7 +110,7 @@ func createLastTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(LastSelector), ps.UseRowTime)
+	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(LastSelector), ps.UseRowTime, ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/limit.go
+++ b/functions/limit.go
@@ -100,7 +100,7 @@ func createLimitTransformation(id execute.DatasetID, mode execute.AccumulationMo
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
-	cache := execute.NewBlockBuilderCache()
+	cache := execute.NewBlockBuilderCache(ctx.Allocator())
 	d := execute.NewDataset(id, mode, cache)
 	t := NewLimitTransformation(d, cache, s)
 	return t, d, nil
@@ -123,11 +123,11 @@ func NewLimitTransformation(d execute.Dataset, cache execute.BlockBuilderCache, 
 	}
 }
 
-func (t *limitTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) {
-	t.d.RetractBlock(execute.ToBlockKey(meta))
+func (t *limitTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) error {
+	return t.d.RetractBlock(execute.ToBlockKey(meta))
 }
 
-func (t *limitTransformation) Process(id execute.DatasetID, b execute.Block) {
+func (t *limitTransformation) Process(id execute.DatasetID, b execute.Block) error {
 	builder, new := t.cache.BlockBuilder(b)
 	if new {
 		execute.AddBlockCols(b, builder)
@@ -180,13 +180,14 @@ func (t *limitTransformation) Process(id execute.DatasetID, b execute.Block) {
 			}
 		}
 	})
+	return nil
 }
 
-func (t *limitTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) {
-	t.d.UpdateWatermark(mark)
+func (t *limitTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return t.d.UpdateWatermark(mark)
 }
-func (t *limitTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) {
-	t.d.UpdateProcessingTime(pt)
+func (t *limitTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
 }
 func (t *limitTransformation) Finish(id execute.DatasetID, err error) {
 	t.d.Finish(err)

--- a/functions/max.go
+++ b/functions/max.go
@@ -74,7 +74,7 @@ func createMaxTransformation(id execute.DatasetID, mode execute.AccumulationMode
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(MaxSelector), ps.UseRowTime)
+	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(MaxSelector), ps.UseRowTime, ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/mean.go
+++ b/functions/mean.go
@@ -52,7 +52,7 @@ type MeanAgg struct {
 }
 
 func createMeanTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, ctx execute.Context) (execute.Transformation, execute.Dataset, error) {
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(MeanAgg))
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(MeanAgg), ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/min.go
+++ b/functions/min.go
@@ -74,7 +74,7 @@ func createMinTransformation(id execute.DatasetID, mode execute.AccumulationMode
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(MinSelector), ps.UseRowTime)
+	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, ctx.Bounds(), new(MinSelector), ps.UseRowTime, ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/sample.go
+++ b/functions/sample.go
@@ -106,7 +106,7 @@ func createSampleTransformation(id execute.DatasetID, mode execute.AccumulationM
 		N:   int(ps.N),
 		Pos: int(ps.Pos),
 	}
-	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, ctx.Bounds(), ss, ps.UseRowTime)
+	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, ctx.Bounds(), ss, ps.UseRowTime, ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/sample_test.go
+++ b/functions/sample_test.go
@@ -95,7 +95,7 @@ func TestSample_Process(t *testing.T) {
 					{execute.Time(80), 3.0, "a", "y"},
 					{execute.Time(90), 10.0, "a", "x"},
 				},
-			}),
+			}, executetest.UnlimitedAllocator),
 			want: [][]int{{
 				0,
 				1,
@@ -134,7 +134,7 @@ func TestSample_Process(t *testing.T) {
 					{execute.Time(80), 3.0, "a", "y"},
 					{execute.Time(90), 10.0, "a", "x"},
 				},
-			}),
+			}, executetest.UnlimitedAllocator),
 			want: [][]int{{
 				0,
 				2,
@@ -168,7 +168,7 @@ func TestSample_Process(t *testing.T) {
 					{execute.Time(80), 3.0, "a", "y"},
 					{execute.Time(90), 10.0, "a", "x"},
 				},
-			}),
+			}, executetest.UnlimitedAllocator),
 			want: [][]int{{
 				1,
 				3,
@@ -202,7 +202,7 @@ func TestSample_Process(t *testing.T) {
 					{execute.Time(80), 3.0, "a", "y"},
 					{execute.Time(90), 10.0, "a", "x"},
 				},
-			}),
+			}, executetest.UnlimitedAllocator),
 			want: [][]int{{
 				0,
 				3,
@@ -235,7 +235,7 @@ func TestSample_Process(t *testing.T) {
 					{execute.Time(80), 3.0, "a", "y"},
 					{execute.Time(90), 10.0, "a", "x"},
 				},
-			}),
+			}, executetest.UnlimitedAllocator),
 			want: [][]int{{
 				1,
 				4,
@@ -267,7 +267,7 @@ func TestSample_Process(t *testing.T) {
 					{execute.Time(80), 3.0, "a", "y"},
 					{execute.Time(90), 10.0, "a", "x"},
 				},
-			}),
+			}, executetest.UnlimitedAllocator),
 			want: [][]int{{
 				2,
 				5,

--- a/functions/set.go
+++ b/functions/set.go
@@ -79,7 +79,7 @@ func createSetTransformation(id execute.DatasetID, mode execute.AccumulationMode
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
-	cache := execute.NewBlockBuilderCache()
+	cache := execute.NewBlockBuilderCache(ctx.Allocator())
 	d := execute.NewDataset(id, mode, cache)
 	t := NewSetTransformation(d, cache, s)
 	return t, d, nil
@@ -106,11 +106,12 @@ func NewSetTransformation(
 	}
 }
 
-func (t *setTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) {
+func (t *setTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) error {
 	// TODO
+	return nil
 }
 
-func (t *setTransformation) Process(id execute.DatasetID, b execute.Block) {
+func (t *setTransformation) Process(id execute.DatasetID, b execute.Block) error {
 	tags := b.Tags()
 	isCommon := false
 	if v, ok := tags[t.key]; ok {
@@ -188,13 +189,14 @@ func (t *setTransformation) Process(id execute.DatasetID, b execute.Block) {
 			}
 		}
 	})
+	return nil
 }
 
-func (t *setTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) {
-	t.d.UpdateWatermark(mark)
+func (t *setTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return t.d.UpdateWatermark(mark)
 }
-func (t *setTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) {
-	t.d.UpdateProcessingTime(pt)
+func (t *setTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
 }
 func (t *setTransformation) Finish(id execute.DatasetID, err error) {
 	t.d.Finish(err)

--- a/functions/skew.go
+++ b/functions/skew.go
@@ -51,7 +51,7 @@ type SkewAgg struct {
 }
 
 func createSkewTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, ctx execute.Context) (execute.Transformation, execute.Dataset, error) {
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(SkewAgg))
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(SkewAgg), ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/spread.go
+++ b/functions/spread.go
@@ -57,7 +57,7 @@ func (s *SpreadProcedureSpec) Copy() plan.ProcedureSpec {
 }
 
 func createSpreadTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, ctx execute.Context) (execute.Transformation, execute.Dataset, error) {
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(SpreadAgg))
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(SpreadAgg), ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/stddev.go
+++ b/functions/stddev.go
@@ -51,7 +51,7 @@ type StddevAgg struct {
 }
 
 func createStddevTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, ctx execute.Context) (execute.Transformation, execute.Dataset, error) {
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(StddevAgg))
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(StddevAgg), ctx.Allocator())
 	return t, d, nil
 }
 

--- a/functions/sum.go
+++ b/functions/sum.go
@@ -72,7 +72,7 @@ func (s *SumProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Proce
 type SumAgg struct{}
 
 func createSumTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, ctx execute.Context) (execute.Transformation, execute.Dataset, error) {
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(SumAgg))
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, ctx.Bounds(), new(SumAgg), ctx.Allocator())
 	return t, d, nil
 }
 func (a *SumAgg) NewBoolAgg() execute.DoBoolAgg {

--- a/functions/window_test.go
+++ b/functions/window_test.go
@@ -579,7 +579,7 @@ func TestFixedWindow_Process(t *testing.T) {
 			stop := start + execute.Time(time.Hour)
 
 			d := executetest.NewDataset(executetest.RandomDatasetID())
-			c := execute.NewBlockBuilderCache()
+			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
 			fw := functions.NewFixedWindowTransformation(
@@ -628,7 +628,9 @@ func TestFixedWindow_Process(t *testing.T) {
 			}
 
 			parentID := executetest.RandomDatasetID()
-			fw.Process(parentID, block0)
+			if err := fw.Process(parentID, block0); err != nil {
+				t.Fatal(err)
+			}
 
 			got := executetest.BlocksFromCache(c)
 

--- a/query.go
+++ b/query.go
@@ -26,6 +26,9 @@ type Options struct {
 	Verbose bool
 	Trace   bool
 	Hosts   []string
+
+	ConcurrencyQuota int
+	MemoryBytesQuota int
 }
 
 var emptyOptions = new(Options)
@@ -92,8 +95,8 @@ func NewController(opts Options) (*Controller, error) {
 		return nil, errors.Wrap(err, "failed to create storage reader")
 	}
 	c := control.Config{
-		ConcurrencyQuota: 10,
-		MemoryBytesQuota: 1e9,
+		ConcurrencyQuota: opts.ConcurrencyQuota,
+		MemoryBytesQuota: int64(opts.MemoryBytesQuota),
 		ExecutorConfig: execute.Config{
 			StorageReader: s,
 		},

--- a/query.go
+++ b/query.go
@@ -92,8 +92,8 @@ func NewController(opts Options) (*Controller, error) {
 		return nil, errors.Wrap(err, "failed to create storage reader")
 	}
 	c := control.Config{
-		ConcurrencyQuota: 20,
-		MemoryBytesQuota: 1e6,
+		ConcurrencyQuota: 10,
+		MemoryBytesQuota: 1e9,
 		ExecutorConfig: execute.Config{
 			StorageReader: s,
 		},

--- a/query.go
+++ b/query.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/ifql/query"
 
 	"github.com/influxdata/ifql/ifql"
+	"github.com/influxdata/ifql/query/control"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
 	"github.com/pkg/errors"
@@ -29,8 +30,8 @@ type Options struct {
 
 var emptyOptions = new(Options)
 
-// Query parses the queryStr according to opts, plans, and returns results and the query specification
-func Query(ctx context.Context, queryStr string, opts *Options) ([]execute.Result, *query.QuerySpec, error) {
+// ExecuteQuery parses the queryStr according to opts, plans, and returns results and the query specification
+func ExecuteQuery(ctx context.Context, queryStr string, opts *Options) ([]execute.Result, *query.QuerySpec, error) {
 	if opts == nil {
 		opts = new(Options)
 	}
@@ -68,8 +69,6 @@ func QueryWithSpec(ctx context.Context, qSpec *query.QuerySpec, opts *Options) (
 	}
 
 	var c execute.Config
-	c.Trace = opts.Trace
-
 	s, err := execute.NewStorageReader(opts.Hosts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create storage reader")
@@ -82,4 +81,22 @@ func QueryWithSpec(ctx context.Context, qSpec *query.QuerySpec, opts *Options) (
 		return nil, nil, errors.Wrap(err, "failed to execute query")
 	}
 	return r, qSpec, nil
+}
+
+type Controller = control.Controller
+type Query = control.Query
+
+func NewController(opts Options) (*Controller, error) {
+	s, err := execute.NewStorageReader(opts.Hosts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create storage reader")
+	}
+	c := control.Config{
+		ConcurrencyQuota: 20,
+		MemoryBytesQuota: 1e6,
+		ExecutorConfig: execute.Config{
+			StorageReader: s,
+		},
+	}
+	return control.New(c), nil
 }

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -1,0 +1,293 @@
+package control
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/plan"
+	"github.com/pkg/errors"
+)
+
+type Controller struct {
+	newQueries    chan *Query
+	lastID        QueryID
+	queriesMu     sync.RWMutex
+	queries       map[QueryID]*Query
+	queryDone     chan *Query
+	cancelRequest chan QueryID
+
+	lplanner plan.LogicalPlanner
+	pplanner plan.Planner
+	executor execute.Executor
+
+	availableConcurrency int
+	availableMemory      int64
+}
+
+type Config struct {
+	ConcurrencyQuota int
+	MemoryBytesQuota int64
+	ExecutorConfig   execute.Config
+}
+
+type QueryID uint64
+
+func New(c Config) *Controller {
+	ctrl := &Controller{
+		newQueries:           make(chan *Query),
+		queries:              make(map[QueryID]*Query),
+		queryDone:            make(chan *Query),
+		cancelRequest:        make(chan QueryID),
+		availableConcurrency: c.ConcurrencyQuota,
+		availableMemory:      c.MemoryBytesQuota,
+		lplanner:             plan.NewLogicalPlanner(),
+		pplanner:             plan.NewPlanner(),
+		executor:             execute.NewExecutor(c.ExecutorConfig),
+	}
+	go ctrl.run()
+	return ctrl
+}
+
+// Query submits a query for execution returning immediately.
+// The spec must not be modified while the query is still active.
+func (c *Controller) Query(ctx context.Context, qSpec *query.QuerySpec) (*Query, error) {
+	if err := qSpec.Validate(); err != nil {
+		return nil, err
+	}
+	id := c.nextID()
+	cctx, cancel := context.WithCancel(ctx)
+	ready := make(chan []execute.Result, 1)
+	q := &Query{
+		id:     id,
+		c:      c,
+		Spec:   *qSpec,
+		now:    time.Now().UTC(),
+		ready:  ready,
+		Ready:  ready,
+		state:  Queued,
+		ctx:    cctx,
+		cancel: cancel,
+	}
+
+	// Add query to the queue
+	c.newQueries <- q
+	return q, nil
+}
+
+func (c *Controller) nextID() QueryID {
+	c.queriesMu.RLock()
+	defer c.queriesMu.RUnlock()
+	ok := true
+	for ok {
+		c.lastID++
+		_, ok = c.queries[c.lastID]
+	}
+	return c.lastID
+}
+
+func (c *Controller) Queries() []*Query {
+	c.queriesMu.RLock()
+	defer c.queriesMu.RUnlock()
+	queries := make([]*Query, 0, len(c.queries))
+	for _, q := range c.queries {
+		queries = append(queries, q)
+	}
+	return queries
+}
+
+func (c *Controller) run() {
+	pq := newPriorityQueue()
+	for {
+		log.Println("Controller", c.availableConcurrency, c.availableMemory)
+		select {
+		// Wait for resources to free
+		case q := <-c.queryDone:
+			c.availableConcurrency += q.concurrency
+			c.availableMemory += q.memory
+			c.queriesMu.Lock()
+			delete(c.queries, q.id)
+			c.queriesMu.Unlock()
+		// Wait for new queries
+		case q := <-c.newQueries:
+			pq.Push(q)
+			c.queriesMu.Lock()
+			c.queries[q.id] = q
+			c.queriesMu.Unlock()
+		// Wait for cancel query requests
+		case id := <-c.cancelRequest:
+			c.queriesMu.RLock()
+			q := c.queries[id]
+			c.queriesMu.RUnlock()
+			q.Cancel()
+		}
+
+		// Peek at head of priority queue
+		q := pq.Peek()
+		if q != nil {
+			if !q.advanceState(Planning) {
+				continue
+			}
+			// Plan query to determine needed resources
+			lp, err := c.lplanner.Plan(&q.Spec)
+			if err != nil {
+				q.SetErr(errors.Wrap(err, "failed to create logical plan"))
+				continue
+			}
+
+			p, err := c.pplanner.Plan(lp, nil, q.now)
+			if err != nil {
+				q.SetErr(errors.Wrap(err, "failed to create physical plan"))
+				continue
+			}
+			q.concurrency = p.Resources.ConcurrencyQuota
+			q.memory = p.Resources.MemoryBytesQuota
+
+			// Check if we have enough resources
+			if c.availableConcurrency >= q.concurrency && c.availableMemory >= q.memory {
+				// Mark resources as consumed
+				c.availableConcurrency -= q.concurrency
+				c.availableMemory -= q.memory
+				pq.Pop()
+
+				// Execute query
+				if !q.advanceState(Executing) {
+					continue
+				}
+				r, err := c.executor.Execute(q.ctx, p)
+				if err != nil {
+					q.SetErr(errors.Wrap(err, "failed to execute query"))
+					continue
+				}
+				q.setResults(r)
+			} // else go back to waiting for new queries or new resources
+		}
+	}
+}
+
+type Query struct {
+	id QueryID
+	c  *Controller
+
+	Spec query.QuerySpec
+	now  time.Time
+
+	err error
+
+	ready chan<- []execute.Result
+	Ready <-chan []execute.Result
+
+	ctx context.Context
+
+	mu     sync.Mutex
+	state  State
+	cancel func()
+
+	concurrency int
+	memory      int64
+}
+
+func (q *Query) ID() QueryID {
+	return q.id
+}
+func (q *Query) Cancel() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.cancel()
+	if q.state != Errored {
+		q.state = Canceled
+	}
+	q.c.queryDone <- q
+	close(q.ready)
+}
+
+func (q *Query) Done() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.state != Canceled && q.state != Errored {
+		q.state = Finished
+		q.c.queryDone <- q
+		close(q.ready)
+	}
+}
+
+func (q *Query) State() State {
+	q.mu.Lock()
+	s := q.state
+	q.mu.Unlock()
+	return s
+}
+
+func (q *Query) isOK() bool {
+	q.mu.Lock()
+	ok := q.state != Canceled && q.state != Errored
+	q.mu.Unlock()
+	return ok
+}
+func (q *Query) Err() error {
+	q.mu.Lock()
+	err := q.err
+	q.mu.Unlock()
+	return err
+}
+func (q *Query) SetErr(err error) {
+	q.mu.Lock()
+	q.err = err
+	q.state = Errored
+	q.mu.Unlock()
+}
+
+func (q *Query) setResults(r []execute.Result) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.state == Executing {
+		q.ready <- r
+	}
+}
+func (q *Query) setState(s State) {
+	q.mu.Lock()
+	q.state = s
+	q.mu.Unlock()
+}
+func (q *Query) advanceState(s State) (ok bool) {
+	q.mu.Lock()
+	ok = q.state != Canceled && q.state != Errored
+	if ok {
+		q.state = s
+	}
+	q.mu.Unlock()
+	return
+}
+
+type State int
+
+const (
+	Queued State = iota
+	Planning
+	Executing
+	Errored
+	Finished
+	Canceled
+)
+
+func (s State) String() string {
+	switch s {
+	case Queued:
+		return "queued"
+	case Planning:
+		return "planning"
+	case Executing:
+		return "executing"
+	case Errored:
+		return "errored"
+	case Finished:
+		return "finished"
+	case Canceled:
+		return "canceled"
+	default:
+		return "unknown"
+	}
+}

--- a/query/control/metrics.go
+++ b/query/control/metrics.go
@@ -1,0 +1,53 @@
+package control
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var queueingGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "ifql_control_current_queueing",
+	Help: "Number of queries currently queueing",
+})
+var requeueingGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "ifql_control_current_requeueing",
+	Help: "Number of queries currently requeueing",
+})
+var planningGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "ifql_control_current_planning",
+	Help: "Number of queries currently planning",
+})
+var executingGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "ifql_control_current_executing",
+	Help: "Number of queries currently executing",
+})
+
+var queueingHist = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "ifql_control_queueing",
+	Help:    "Histogram of queueing durations",
+	Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
+})
+var requeueingHist = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "ifql_control_requeueing",
+	Help:    "Histogram of requeueing durations",
+	Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
+})
+var planningHist = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "ifql_control_planning",
+	Help:    "Histogram of planning durations",
+	Buckets: prometheus.ExponentialBuckets(1e-5, 5, 7),
+})
+var executingHist = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "ifql_control_executing",
+	Help:    "Histogram of executing durations",
+	Buckets: prometheus.ExponentialBuckets(1e-3, 5, 7),
+})
+
+func init() {
+	prometheus.MustRegister(queueingGauge)
+	prometheus.MustRegister(requeueingGauge)
+	prometheus.MustRegister(planningGauge)
+	prometheus.MustRegister(executingGauge)
+
+	prometheus.MustRegister(queueingHist)
+	prometheus.MustRegister(requeueingHist)
+	prometheus.MustRegister(planningHist)
+	prometheus.MustRegister(executingHist)
+}

--- a/query/control/queue.go
+++ b/query/control/queue.go
@@ -1,0 +1,67 @@
+package control
+
+import "container/heap"
+
+// priorityQueue implements heap.Interface and holds Query objects.
+type priorityQueue []*Query
+
+func (pq priorityQueue) Len() int { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq[i].Spec.Resources.Priority < pq[j].Spec.Resources.Priority
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	q := x.(*Query)
+	*pq = append(*pq, q)
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	q := old[n-1]
+	*pq = old[0 : n-1]
+	return q
+}
+
+type PriorityQueue struct {
+	queue priorityQueue
+}
+
+func newPriorityQueue() *PriorityQueue {
+	return &PriorityQueue{
+		queue: make(priorityQueue, 0, 100),
+	}
+}
+
+func (p *PriorityQueue) Push(q *Query) {
+	heap.Push(&p.queue, q)
+}
+
+func (p *PriorityQueue) Peek() *Query {
+	for {
+		if p.queue.Len() == 0 {
+			return nil
+		}
+		q := p.queue[0]
+		if q.isOK() {
+			return q
+		}
+		heap.Pop(&p.queue)
+	}
+}
+func (p *PriorityQueue) Pop() *Query {
+	for {
+		if p.queue.Len() == 0 {
+			return nil
+		}
+		q := heap.Pop(&p.queue).(*Query)
+		if q.isOK() {
+			return q
+		}
+	}
+}

--- a/query/execute/aggergate_test.go
+++ b/query/execute/aggergate_test.go
@@ -260,14 +260,16 @@ func TestAggregate_Process(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
-			c := execute.NewBlockBuilderCache()
+			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
 			agg := execute.NewAggregateTransformation(d, c, tc.bounds, new(functions.SumAgg))
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {
-				agg.Process(parentID, b)
+				if err := agg.Process(parentID, b); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			want := tc.want(tc.bounds)

--- a/query/execute/aggregate.go
+++ b/query/execute/aggregate.go
@@ -18,19 +18,19 @@ func NewAggregateTransformation(d Dataset, c BlockBuilderCache, bounds Bounds, a
 	}
 }
 
-func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, bounds Bounds, agg Aggregate) (*aggregateTransformation, Dataset) {
-	cache := NewBlockBuilderCache()
+func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, bounds Bounds, agg Aggregate, a *Allocator) (*aggregateTransformation, Dataset) {
+	cache := NewBlockBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewAggregateTransformation(d, cache, bounds, agg), d
 }
 
-func (t *aggregateTransformation) RetractBlock(id DatasetID, meta BlockMetadata) {
+func (t *aggregateTransformation) RetractBlock(id DatasetID, meta BlockMetadata) error {
 	//TODO(nathanielc): Store intermediate state for retractions
 	key := ToBlockKey(meta)
-	t.d.RetractBlock(key)
+	return t.d.RetractBlock(key)
 }
 
-func (t *aggregateTransformation) Process(id DatasetID, b Block) {
+func (t *aggregateTransformation) Process(id DatasetID, b Block) error {
 	cols := b.Cols()
 	valueCol := ValueCol(cols)
 
@@ -100,13 +100,14 @@ func (t *aggregateTransformation) Process(id DatasetID, b Block) {
 		v := vf.(StringValueFunc)
 		builder.AppendString(1, v.ValueString())
 	}
+	return nil
 }
 
-func (t *aggregateTransformation) UpdateWatermark(id DatasetID, mark Time) {
-	t.d.UpdateWatermark(mark)
+func (t *aggregateTransformation) UpdateWatermark(id DatasetID, mark Time) error {
+	return t.d.UpdateWatermark(mark)
 }
-func (t *aggregateTransformation) UpdateProcessingTime(id DatasetID, pt Time) {
-	t.d.UpdateProcessingTime(pt)
+func (t *aggregateTransformation) UpdateProcessingTime(id DatasetID, pt Time) error {
+	return t.d.UpdateProcessingTime(pt)
 }
 func (t *aggregateTransformation) Finish(id DatasetID, err error) {
 	t.d.Finish(err)

--- a/query/execute/allocator.go
+++ b/query/execute/allocator.go
@@ -14,6 +14,9 @@ const (
 	timeSize    = 8
 )
 
+// Allocator tracks the amount of memory being consumed by a query.
+// The allocator provides methods similar to make and append, to allocate large slices of data.
+// The allocator also provides a Free method to account for when memory will be freed.
 type Allocator struct {
 	Limit          int64
 	bytesAllocated int64
@@ -29,10 +32,13 @@ func (a *Allocator) count(n, size int) (c int64) {
 	}
 	return
 }
+
+// Free informs the allocator that memory has been freed.
 func (a *Allocator) Free(n, size int) {
 	a.count(-n, size)
 }
 
+// Max reports the maximum amount of allocated memory at any point in the query.
 func (a *Allocator) Max() int64 {
 	return atomic.LoadInt64(&a.maxAllocated)
 }
@@ -47,11 +53,14 @@ func (a *Allocator) account(n, size int) {
 		})
 	}
 }
+
+// Bools makes a slice of bool values.
 func (a *Allocator) Bools(l, c int) []bool {
 	a.account(c, boolSize)
 	return make([]bool, l, c)
 }
 
+// AppendBools appends bools to a slice
 func (a *Allocator) AppendBools(slice []bool, vs ...bool) []bool {
 	if cap(slice)-len(slice) > len(vs) {
 		return append(slice, vs...)
@@ -62,11 +71,13 @@ func (a *Allocator) AppendBools(slice []bool, vs ...bool) []bool {
 	return s
 }
 
+// Ints makes a slice of int64 values.
 func (a *Allocator) Ints(l, c int) []int64 {
 	a.account(c, int64Size)
 	return make([]int64, l, c)
 }
 
+// AppendInts appends int64s to a slice
 func (a *Allocator) AppendInts(slice []int64, vs ...int64) []int64 {
 	if cap(slice)-len(slice) > len(vs) {
 		return append(slice, vs...)
@@ -76,11 +87,14 @@ func (a *Allocator) AppendInts(slice []int64, vs ...int64) []int64 {
 	a.account(diff, int64Size)
 	return s
 }
+
+// UInts makes a slice of uint64 values.
 func (a *Allocator) UInts(l, c int) []uint64 {
 	a.account(c, uint64Size)
 	return make([]uint64, l, c)
 }
 
+// AppendUInts appends uint64s to a slice
 func (a *Allocator) AppendUInts(slice []uint64, vs ...uint64) []uint64 {
 	if cap(slice)-len(slice) > len(vs) {
 		return append(slice, vs...)
@@ -91,11 +105,13 @@ func (a *Allocator) AppendUInts(slice []uint64, vs ...uint64) []uint64 {
 	return s
 }
 
+// Floats makes a slice of float64 values.
 func (a *Allocator) Floats(l, c int) []float64 {
 	a.account(c, float64Size)
 	return make([]float64, l, c)
 }
 
+// AppendFloats appends float64s to a slice
 func (a *Allocator) AppendFloats(slice []float64, vs ...float64) []float64 {
 	if cap(slice)-len(slice) > len(vs) {
 		return append(slice, vs...)
@@ -106,11 +122,15 @@ func (a *Allocator) AppendFloats(slice []float64, vs ...float64) []float64 {
 	return s
 }
 
+// Strings makes a slice of string values.
+// Only the string headers are accounted for.
 func (a *Allocator) Strings(l, c int) []string {
 	a.account(c, stringSize)
 	return make([]string, l, c)
 }
 
+// AppendStrings appends strings to a slice.
+// Only the string headers are accounted for.
 func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
 	//TODO(nathanielc): Account for actual size of strings
 	if cap(slice)-len(slice) > len(vs) {
@@ -122,11 +142,13 @@ func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
 	return s
 }
 
+// Times makes a slice of Time values.
 func (a *Allocator) Times(l, c int) []Time {
 	a.account(c, timeSize)
 	return make([]Time, l, c)
 }
 
+// AppendTimes appends Times to a slice
 func (a *Allocator) AppendTimes(slice []Time, vs ...Time) []Time {
 	if cap(slice)-len(slice) > len(vs) {
 		return append(slice, vs...)

--- a/query/execute/allocator.go
+++ b/query/execute/allocator.go
@@ -1,0 +1,148 @@
+package execute
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+const (
+	boolSize    = 1
+	int64Size   = 8
+	uint64Size  = 8
+	float64Size = 8
+	stringSize  = 16
+	timeSize    = 8
+)
+
+type Allocator struct {
+	Limit          int64
+	bytesAllocated int64
+	maxAllocated   int64
+}
+
+func (a *Allocator) count(n, size int) (c int64) {
+	c = atomic.AddInt64(&a.bytesAllocated, int64(n*size))
+	for max := atomic.LoadInt64(&a.maxAllocated); c > max; max = atomic.LoadInt64(&a.maxAllocated) {
+		if atomic.CompareAndSwapInt64(&a.maxAllocated, max, c) {
+			return
+		}
+	}
+	return
+}
+func (a *Allocator) Free(n, size int) {
+	a.count(-n, size)
+}
+
+func (a *Allocator) Max() int64 {
+	return atomic.LoadInt64(&a.maxAllocated)
+}
+
+func (a *Allocator) account(n, size int) {
+	if want := a.count(n, size); want > a.Limit {
+		allocated := a.count(-n, size)
+		panic(AllocError{
+			Limit:     a.Limit,
+			Allocated: allocated,
+			Wanted:    want - allocated,
+		})
+	}
+}
+func (a *Allocator) Bools(l, c int) []bool {
+	a.account(c, boolSize)
+	return make([]bool, l, c)
+}
+
+func (a *Allocator) AppendBools(slice []bool, vs ...bool) []bool {
+	if cap(slice)-len(slice) > len(vs) {
+		return append(slice, vs...)
+	}
+	s := append(slice, vs...)
+	diff := cap(s) - cap(slice)
+	a.account(diff, boolSize)
+	return s
+}
+
+func (a *Allocator) Ints(l, c int) []int64 {
+	a.account(c, int64Size)
+	return make([]int64, l, c)
+}
+
+func (a *Allocator) AppendInts(slice []int64, vs ...int64) []int64 {
+	if cap(slice)-len(slice) > len(vs) {
+		return append(slice, vs...)
+	}
+	s := append(slice, vs...)
+	diff := cap(s) - cap(slice)
+	a.account(diff, int64Size)
+	return s
+}
+func (a *Allocator) UInts(l, c int) []uint64 {
+	a.account(c, uint64Size)
+	return make([]uint64, l, c)
+}
+
+func (a *Allocator) AppendUInts(slice []uint64, vs ...uint64) []uint64 {
+	if cap(slice)-len(slice) > len(vs) {
+		return append(slice, vs...)
+	}
+	s := append(slice, vs...)
+	diff := cap(s) - cap(slice)
+	a.account(diff, uint64Size)
+	return s
+}
+
+func (a *Allocator) Floats(l, c int) []float64 {
+	a.account(c, float64Size)
+	return make([]float64, l, c)
+}
+
+func (a *Allocator) AppendFloats(slice []float64, vs ...float64) []float64 {
+	if cap(slice)-len(slice) > len(vs) {
+		return append(slice, vs...)
+	}
+	s := append(slice, vs...)
+	diff := cap(s) - cap(slice)
+	a.account(diff, float64Size)
+	return s
+}
+
+func (a *Allocator) Strings(l, c int) []string {
+	a.account(c, stringSize)
+	return make([]string, l, c)
+}
+
+func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
+	//TODO(nathanielc): Account for actual size of strings
+	if cap(slice)-len(slice) > len(vs) {
+		return append(slice, vs...)
+	}
+	s := append(slice, vs...)
+	diff := cap(s) - cap(slice)
+	a.account(diff, stringSize)
+	return s
+}
+
+func (a *Allocator) Times(l, c int) []Time {
+	a.account(c, timeSize)
+	return make([]Time, l, c)
+}
+
+func (a *Allocator) AppendTimes(slice []Time, vs ...Time) []Time {
+	if cap(slice)-len(slice) > len(vs) {
+		return append(slice, vs...)
+	}
+	s := append(slice, vs...)
+	diff := cap(s) - cap(slice)
+	a.account(diff, timeSize)
+	return s
+}
+
+type AllocError struct {
+	Limit     int64
+	Allocated int64
+	Wanted    int64
+}
+
+func (a AllocError) Error() string {
+	return fmt.Sprintf("allocation limit reached: limit %d, allocated: %d, wanted: %d", a.Limit, a.Allocated, a.Wanted)
+}

--- a/query/execute/dispatcher.go
+++ b/query/execute/dispatcher.go
@@ -1,0 +1,117 @@
+package execute
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+)
+
+// Dispatcher schedules work.
+type Dispatcher interface {
+	// Schedule fn to be executed
+	Schedule(fn ScheduleFunc)
+}
+
+// ScheduleFunc is a function that represents work to do.
+// The throughput is the maximum number of messages to process for this scheduling.
+type ScheduleFunc func(throughput int)
+
+// poolDispatcher implements Dispatcher using a pool of goroutines.
+type poolDispatcher struct {
+	work chan ScheduleFunc
+
+	throughput int
+
+	mu      sync.Mutex
+	closed  bool
+	closing chan struct{}
+	wg      sync.WaitGroup
+	err     error
+	errC    chan error
+}
+
+func newPoolDispatcher(throughput int) *poolDispatcher {
+	return &poolDispatcher{
+		throughput: throughput,
+		work:       make(chan ScheduleFunc, 100),
+		closing:    make(chan struct{}),
+		errC:       make(chan error, 1),
+	}
+}
+
+func (d *poolDispatcher) Schedule(fn ScheduleFunc) {
+	select {
+	case d.work <- fn:
+	case <-d.closing:
+	}
+}
+
+func (d *poolDispatcher) Start(n int, ctx context.Context) {
+	d.wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer d.wg.Done()
+			// Setup panic handling on the worker goroutines
+			defer func() {
+				if e := recover(); e != nil {
+					var err error
+					switch e := e.(type) {
+					case error:
+						err = e
+					default:
+						err = fmt.Errorf("%v", e)
+					}
+					d.setErr(fmt.Errorf("panic: %v\n%s", err, debug.Stack()))
+				}
+			}()
+			d.run(ctx)
+		}()
+	}
+}
+
+// Err returns a channel with will produce an error if encountered.
+func (d *poolDispatcher) Err() <-chan error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.errC
+}
+
+func (d *poolDispatcher) setErr(err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// TODO(nathanielc): Collect all error information.
+	if d.err == nil {
+		d.err = err
+		d.errC <- err
+	}
+}
+
+//Stop the dispatcher.
+func (d *poolDispatcher) Stop() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return d.err
+	}
+	d.closed = true
+	close(d.closing)
+	d.wg.Wait()
+	return d.err
+}
+
+// run is the logic executed by each worker goroutine in the pool.
+func (d *poolDispatcher) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			// Immediately return, do not process any more work
+			return
+		case <-d.closing:
+			// We are done, nothing left to do.
+			return
+		case fn := <-d.work:
+			fn(d.throughput)
+		}
+	}
+}

--- a/query/execute/dispatcher.go
+++ b/query/execute/dispatcher.go
@@ -7,7 +7,9 @@ import (
 	"sync"
 )
 
-// Dispatcher schedules work.
+// Dispatcher schedules work for a query.
+// Each transformation submits work to be done to the dispatcher.
+// Then the dispatcher schedules to work based on the available resources.
 type Dispatcher interface {
 	// Schedule fn to be executed
 	Schedule(fn ScheduleFunc)

--- a/query/execute/executetest/allocator.go
+++ b/query/execute/executetest/allocator.go
@@ -1,0 +1,11 @@
+package executetest
+
+import (
+	"math"
+
+	"github.com/influxdata/ifql/query/execute"
+)
+
+var UnlimitedAllocator = &execute.Allocator{
+	Limit: math.MaxInt64,
+}

--- a/query/execute/executetest/block.go
+++ b/query/execute/executetest/block.go
@@ -14,6 +14,8 @@ type Block struct {
 	Data [][]interface{}
 }
 
+func (b *Block) RefCount(n int) {}
+
 func (b *Block) Bounds() execute.Bounds {
 	return b.Bnds
 }
@@ -114,7 +116,7 @@ func (v *ValueIterator) AtTime(i int, j int) execute.Time {
 func BlocksFromCache(c execute.DataCache) []*Block {
 	var blocks []*Block
 	c.ForEach(func(key execute.BlockKey) {
-		b := c.Block(key)
+		b, _ := c.Block(key)
 		blocks = append(blocks, ConvertBlock(b))
 	})
 	return blocks

--- a/query/execute/executetest/transformation.go
+++ b/query/execute/executetest/transformation.go
@@ -17,14 +17,16 @@ func ProcessTestHelper(
 	t.Helper()
 
 	d := NewDataset(RandomDatasetID())
-	c := execute.NewBlockBuilderCache()
+	c := execute.NewBlockBuilderCache(UnlimitedAllocator)
 	c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
 	tx := create(d, c)
 
 	parentID := RandomDatasetID()
 	for _, b := range data {
-		tx.Process(parentID, b)
+		if err := tx.Process(parentID, b); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	got := BlocksFromCache(c)

--- a/query/execute/executor.go
+++ b/query/execute/executor.go
@@ -3,7 +3,6 @@ package execute
 import (
 	"context"
 	"fmt"
-	"log"
 	"runtime/debug"
 
 	"github.com/influxdata/ifql/query"
@@ -188,7 +187,6 @@ func (es *executionState) do(ctx context.Context) {
 		if err != nil {
 			es.abort(err)
 		}
-		log.Println("max allocated", es.alloc.Max())
 	}()
 }
 

--- a/query/execute/executor_test.go
+++ b/query/execute/executor_test.go
@@ -2,6 +2,7 @@ package execute_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -10,49 +11,46 @@ import (
 	"github.com/influxdata/ifql/functions"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/execute/executetest"
 	"github.com/influxdata/ifql/query/plan"
 )
-
-var allowUnexported = cmp.AllowUnexported(blockList{}, block{})
 
 var epoch = time.Unix(0, 0)
 
 func TestExecutor_Execute(t *testing.T) {
 	testCases := []struct {
 		name string
-		src  []block
+		src  []execute.Block
 		plan *plan.PlanSpec
-		exp  []blockList
+		exp  [][]*executetest.Block
 	}{
 		{
 			name: "simple aggregate",
-			src: []block{
-				{
-					bounds: execute.Bounds{
-						Start: 1,
-						Stop:  5,
-					},
-					tags: execute.Tags{},
-					points: []point{
-						{Value: 1.0, Time: 0},
-						{Value: 2.0, Time: 1},
-						{Value: 3.0, Time: 2},
-						{Value: 4.0, Time: 3},
-						{Value: 5.0, Time: 4},
-					},
-					cols: []execute.ColMeta{
-						execute.TimeCol,
-						execute.ColMeta{
-							Label: execute.ValueColLabel,
-							Type:  execute.TFloat,
-						},
+			src: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  5,
+				},
+				ColMeta: []execute.ColMeta{
+					execute.TimeCol,
+					execute.ColMeta{
+						Label: execute.ValueColLabel,
+						Type:  execute.TFloat,
 					},
 				},
-			},
+				Data: [][]interface{}{
+					{execute.Time(0), 1.0},
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.0},
+					{execute.Time(4), 5.0},
+				},
+			}},
 			plan: &plan.PlanSpec{
 				Now: epoch.Add(5),
 				Resources: query.ResourceManagement{
 					ConcurrencyQuota: 1,
+					MemoryBytesQuota: math.MaxInt64,
 				},
 				Bounds: plan.BoundsSpec{
 					Start: query.Time{Absolute: time.Unix(0, 1)},
@@ -86,53 +84,50 @@ func TestExecutor_Execute(t *testing.T) {
 					plan.ProcedureIDFromOperationID("sum"),
 				},
 			},
-			exp: []blockList{{
-				blocks: []block{{
-					bounds: execute.Bounds{
-						Start: 1,
-						Stop:  5,
-					},
-					tags: execute.Tags{},
-					points: []point{
-						{Value: 15.0, Time: 5},
-					},
-					cols: []execute.ColMeta{
-						execute.TimeCol,
-						execute.ColMeta{
-							Label: execute.ValueColLabel,
-							Type:  execute.TFloat,
-						},
-					},
-				}},
-			}},
-		},
-		{
-			name: "simple join",
-			src: []block{{
-				bounds: execute.Bounds{
+			exp: [][]*executetest.Block{[]*executetest.Block{{
+				Bnds: execute.Bounds{
 					Start: 1,
 					Stop:  5,
 				},
-				tags: execute.Tags{},
-				points: []point{
-					{Value: int64(1), Time: 0},
-					{Value: int64(2), Time: 1},
-					{Value: int64(3), Time: 2},
-					{Value: int64(4), Time: 3},
-					{Value: int64(5), Time: 4},
+				ColMeta: []execute.ColMeta{
+					execute.TimeCol,
+					execute.ColMeta{
+						Label: execute.ValueColLabel,
+						Type:  execute.TFloat,
+					},
 				},
-				cols: []execute.ColMeta{
+				Data: [][]interface{}{
+					{execute.Time(5), 15.0},
+				},
+			}}},
+		},
+		{
+			name: "simple join",
+			src: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  5,
+				},
+				ColMeta: []execute.ColMeta{
 					execute.TimeCol,
 					execute.ColMeta{
 						Label: execute.ValueColLabel,
 						Type:  execute.TInt,
 					},
 				},
+				Data: [][]interface{}{
+					{execute.Time(0), int64(1)},
+					{execute.Time(1), int64(2)},
+					{execute.Time(2), int64(3)},
+					{execute.Time(3), int64(4)},
+					{execute.Time(4), int64(5)},
+				},
 			}},
 			plan: &plan.PlanSpec{
 				Now: epoch.Add(5),
 				Resources: query.ResourceManagement{
 					ConcurrencyQuota: 1,
+					MemoryBytesQuota: math.MaxInt64,
 				},
 				Bounds: plan.BoundsSpec{
 					Start: query.Time{Absolute: time.Unix(0, 1)},
@@ -191,32 +186,27 @@ func TestExecutor_Execute(t *testing.T) {
 							plan.ProcedureIDFromOperationID("sum"),
 							plan.ProcedureIDFromOperationID("count"),
 						},
-						Children: nil,
-					},
-				},
+						Children: nil}},
 				Results: []plan.ProcedureID{
 					plan.ProcedureIDFromOperationID("join"),
 				},
 			},
-			exp: []blockList{{
-				blocks: []block{{
-					bounds: execute.Bounds{
-						Start: 1,
-						Stop:  5,
+			exp: [][]*executetest.Block{[]*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  5,
+				},
+				ColMeta: []execute.ColMeta{
+					execute.TimeCol,
+					execute.ColMeta{
+						Label: execute.ValueColLabel,
+						Type:  execute.TInt,
 					},
-					tags: execute.Tags{},
-					points: []point{
-						{Value: int64(3), Time: 5},
-					},
-					cols: []execute.ColMeta{
-						execute.TimeCol,
-						execute.ColMeta{
-							Label: execute.ValueColLabel,
-							Type:  execute.TInt,
-						},
-					},
-				}},
-			}},
+				},
+				Data: [][]interface{}{
+					{execute.Time(5), int64(3)},
+				},
+			}}},
 		},
 	}
 
@@ -231,20 +221,25 @@ func TestExecutor_Execute(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := make([]blockList, len(results))
+			got := make([][]*executetest.Block, len(results))
 			for i, r := range results {
-				got[i] = convertToBlockList(r)
+				if err := r.Blocks().Do(func(b execute.Block) error {
+					got[i] = append(got[i], executetest.ConvertBlock(b))
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
 			}
 
-			if !cmp.Equal(got, tc.exp, allowUnexported) {
-				t.Error("unexpected results -want/+got", cmp.Diff(tc.exp, got, allowUnexported))
+			if !cmp.Equal(got, tc.exp) {
+				t.Error("unexpected results -want/+got", cmp.Diff(tc.exp, got))
 			}
 		})
 	}
 }
 
 type storageReader struct {
-	blocks []block
+	blocks []execute.Block
 }
 
 func (s storageReader) Close() {}
@@ -258,169 +253,11 @@ type storageBlockIterator struct {
 	s storageReader
 }
 
-func (bi *storageBlockIterator) Do(f func(execute.Block)) error {
+func (bi *storageBlockIterator) Do(f func(execute.Block) error) error {
 	for _, b := range bi.s.blocks {
-		f(b)
-	}
-	return nil
-}
-
-type blockList struct {
-	blocks []block
-	bounds execute.Bounds
-}
-
-func (df blockList) Bounds() execute.Bounds {
-	return df.bounds
-}
-
-func (df blockList) Blocks() execute.BlockIterator {
-	return &blockIterator{df.blocks}
-}
-
-func convertToBlockList(r execute.Result) blockList {
-	bl := blockList{}
-	blocks := r.Blocks()
-	err := blocks.Do(func(b execute.Block) {
-		bl.blocks = append(bl.blocks, convertToTestBlock(b))
-	})
-	if err != nil {
-		panic(err)
-	}
-	return bl
-}
-
-type blockIterator struct {
-	blocks []block
-}
-
-func (bi *blockIterator) Do(f func(execute.Block)) error {
-	for _, b := range bi.blocks {
-		f(b)
-	}
-	return nil
-}
-
-type block struct {
-	bounds execute.Bounds
-	tags   execute.Tags
-	points []point
-	cols   []execute.ColMeta
-}
-
-type point struct {
-	Value interface{}
-	Time  execute.Time
-	Tags  execute.Tags
-}
-
-func (b block) Bounds() execute.Bounds {
-	return b.bounds
-}
-
-func (b block) Tags() execute.Tags {
-	return b.tags
-}
-func (b block) Cols() []execute.ColMeta {
-	return b.cols
-}
-
-func (b block) Col(c int) execute.ValueIterator {
-	return &valueIterator{points: b.points, cols: b.cols}
-}
-func (b block) Values() execute.ValueIterator {
-	return &valueIterator{points: b.points, cols: b.cols}
-}
-func (b block) Times() execute.ValueIterator {
-	return &valueIterator{points: b.points, cols: b.cols}
-}
-
-type valueIterator struct {
-	points []point
-	cols   []execute.ColMeta
-}
-
-func (itr *valueIterator) Cols() []execute.ColMeta {
-	return itr.cols
-}
-func (itr *valueIterator) DoBool(f func([]bool, execute.RowReader)) {
-	for _, p := range itr.points {
-		f([]bool{p.Value.(bool)}, itr)
-	}
-}
-func (itr *valueIterator) DoInt(f func([]int64, execute.RowReader)) {
-	for _, p := range itr.points {
-		f([]int64{p.Value.(int64)}, itr)
-	}
-}
-func (itr *valueIterator) DoUInt(f func([]uint64, execute.RowReader)) {
-	for _, p := range itr.points {
-		f([]uint64{p.Value.(uint64)}, itr)
-	}
-}
-func (itr *valueIterator) DoFloat(f func([]float64, execute.RowReader)) {
-	for _, p := range itr.points {
-		f([]float64{p.Value.(float64)}, itr)
-	}
-}
-func (itr *valueIterator) DoString(f func([]string, execute.RowReader)) {
-}
-func (itr *valueIterator) DoTime(f func([]execute.Time, execute.RowReader)) {
-	for _, p := range itr.points {
-		f([]execute.Time{p.Time}, itr)
-	}
-}
-func (itr *valueIterator) AtBool(i, j int) bool {
-	return itr.points[i].Value.(bool)
-}
-func (itr *valueIterator) AtInt(i, j int) int64 {
-	return itr.points[i].Value.(int64)
-}
-func (itr *valueIterator) AtUInt(i, j int) uint64 {
-	return itr.points[i].Value.(uint64)
-}
-func (itr *valueIterator) AtFloat(i, j int) float64 {
-	return itr.points[i].Value.(float64)
-}
-func (itr *valueIterator) AtString(i, j int) string {
-	return itr.points[i].Tags[itr.cols[j].Label]
-}
-func (itr *valueIterator) AtTime(i, j int) execute.Time {
-	return itr.points[i].Time
-}
-
-func convertToTestBlock(b execute.Block) block {
-	cols := b.Cols()
-	blk := block{
-		bounds: b.Bounds(),
-		tags:   b.Tags(),
-		cols:   cols,
-	}
-	valueIdx := execute.ValueIdx(cols)
-	valueType := cols[valueIdx].Type
-	times := b.Times()
-	times.DoTime(func(ts []execute.Time, rr execute.RowReader) {
-		for i, time := range ts {
-			var v interface{}
-			switch valueType {
-			case execute.TBool:
-				v = rr.AtBool(i, valueIdx)
-			case execute.TInt:
-				v = rr.AtInt(i, valueIdx)
-			case execute.TUInt:
-				v = rr.AtUInt(i, valueIdx)
-			case execute.TFloat:
-				v = rr.AtFloat(i, valueIdx)
-			case execute.TString:
-				v = rr.AtString(i, valueIdx)
-			}
-			tags := execute.TagsForRow(i, rr)
-			blk.points = append(blk.points, point{
-				Time:  time,
-				Value: v,
-				Tags:  tags,
-			})
+		if err := f(b); err != nil {
+			return err
 		}
-	})
-	return blk
+	}
+	return nil
 }

--- a/query/execute/expression.go
+++ b/query/execute/expression.go
@@ -143,7 +143,7 @@ func toComparisonOperator(o expression.Operator) (storage.Node_Comparison, error
 
 func ExpressionNames(n expression.Node) []string {
 	var names []string
-	expression.Walk(n, func(n expression.Node) error {
+	_ = expression.Walk(n, func(n expression.Node) error {
 		if rn, ok := n.(*expression.ReferenceNode); ok {
 			found := false
 			for _, n := range names {

--- a/query/execute/queue.go
+++ b/query/execute/queue.go
@@ -1,0 +1,64 @@
+package execute
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// MessageQueue provides a concurrency safe queue for messages.
+// The queue must have a single consumer calling Pop.
+type MessageQueue interface {
+	Push(Message)
+	Pop() Message
+}
+
+type unboundedMessageQueue struct {
+	buf  []Message
+	head int
+	tail int
+	mu   sync.Mutex
+	len  int32
+}
+
+func newMessageQueue(n int) *unboundedMessageQueue {
+	return &unboundedMessageQueue{
+		buf: make([]Message, n),
+	}
+}
+
+func (q *unboundedMessageQueue) Push(m Message) {
+	q.mu.Lock()
+	size := len(q.buf)
+	q.tail = (q.tail + 1) % size
+	if q.tail == q.head {
+		// Resize
+		buf := make([]Message, size*2)
+		copy(buf, q.buf[q.head:])
+		copy(buf[size-q.head:], q.buf[:q.head])
+		q.head = 0
+		q.tail = size
+		q.buf = buf
+	}
+	atomic.AddInt32(&q.len, 1)
+	q.buf[q.tail] = m
+	q.mu.Unlock()
+}
+
+func (q *unboundedMessageQueue) Len() int {
+	return int(atomic.LoadInt32(&q.len))
+}
+
+func (q *unboundedMessageQueue) Pop() Message {
+	if q.Len() == 0 {
+		return nil
+	}
+
+	q.mu.Lock()
+	size := len(q.buf)
+	q.head = (q.head + 1) % size
+	m := q.buf[q.head]
+	q.buf[q.head] = nil
+	atomic.AddInt32(&q.len, -1)
+	q.mu.Unlock()
+	return m
+}

--- a/query/execute/result.go
+++ b/query/execute/result.go
@@ -33,24 +33,26 @@ func newResultSink() *resultSink {
 	}
 }
 
-func (s *resultSink) RetractBlock(DatasetID, BlockMetadata) {
+func (s *resultSink) RetractBlock(DatasetID, BlockMetadata) error {
 	//TODO implement
+	return nil
 }
 
-func (s *resultSink) Process(id DatasetID, b Block) {
+func (s *resultSink) Process(id DatasetID, b Block) error {
 	select {
 	case s.blocks <- resultMessage{
 		block: b,
 	}:
 	case <-s.aborted:
 	}
+	return nil
 }
 
 func (s *resultSink) Blocks() BlockIterator {
 	return s
 }
 
-func (s *resultSink) Do(f func(Block)) error {
+func (s *resultSink) Do(f func(Block) error) error {
 	for {
 		select {
 		case err := <-s.abortErr:
@@ -62,16 +64,20 @@ func (s *resultSink) Do(f func(Block)) error {
 			if msg.err != nil {
 				return msg.err
 			}
-			f(msg.block)
+			if err := f(msg.block); err != nil {
+				return err
+			}
 		}
 	}
 }
 
-func (s *resultSink) UpdateWatermark(id DatasetID, mark Time) {
+func (s *resultSink) UpdateWatermark(id DatasetID, mark Time) error {
 	//Nothing to do
+	return nil
 }
-func (s *resultSink) UpdateProcessingTime(id DatasetID, t Time) {
+func (s *resultSink) UpdateProcessingTime(id DatasetID, t Time) error {
 	//Nothing to do
+	return nil
 }
 func (s *resultSink) SetParents(ids []DatasetID) {
 }

--- a/query/execute/selector_test.go
+++ b/query/execute/selector_test.go
@@ -310,14 +310,16 @@ func TestRowSelector_Process(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
-			c := execute.NewBlockBuilderCache()
+			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
 			selector := execute.NewRowSelectorTransformation(d, c, tc.bounds, new(functions.MinSelector), tc.useRowTime)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {
-				selector.Process(parentID, b)
+				if err := selector.Process(parentID, b); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			want := tc.want(tc.bounds)
@@ -632,14 +634,16 @@ func TestIndexSelector_Process(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
-			c := execute.NewBlockBuilderCache()
+			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
 			selector := execute.NewIndexSelectorTransformation(d, c, tc.bounds, new(functions.FirstSelector), tc.useRowTime)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {
-				selector.Process(parentID, b)
+				if err := selector.Process(parentID, b); err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			want := tc.want(tc.bounds)

--- a/query/execute/source.go
+++ b/query/execute/source.go
@@ -15,7 +15,7 @@ type Node interface {
 
 type Source interface {
 	Node
-	Runner
+	Run(ctx context.Context)
 }
 
 type CreateSource func(spec plan.ProcedureSpec, id DatasetID, sr StorageReader, ctx Context) Source

--- a/query/execute/transformation.go
+++ b/query/execute/transformation.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Transformation interface {
-	RetractBlock(id DatasetID, meta BlockMetadata)
-	Process(id DatasetID, b Block)
-	UpdateWatermark(id DatasetID, t Time)
-	UpdateProcessingTime(id DatasetID, t Time)
+	RetractBlock(id DatasetID, meta BlockMetadata) error
+	Process(id DatasetID, b Block) error
+	UpdateWatermark(id DatasetID, t Time) error
+	UpdateProcessingTime(id DatasetID, t Time) error
 	Finish(id DatasetID, err error)
 	SetParents(ids []DatasetID)
 }
@@ -19,6 +19,7 @@ type Transformation interface {
 type Context interface {
 	ResolveTime(qt query.Time) Time
 	Bounds() Bounds
+	Allocator() *Allocator
 }
 
 type CreateTransformation func(id DatasetID, mode AccumulationMode, spec plan.ProcedureSpec, ctx Context) (Transformation, Dataset, error)

--- a/query/format.go
+++ b/query/format.go
@@ -29,7 +29,7 @@ func (f formatter) Format(fs fmt.State, c rune) {
 
 func (f formatter) format(fs fmt.State) {
 	fmt.Fprint(fs, "digraph QuerySpec {\n")
-	f.q.Walk(func(o *Operation) error {
+	_ = f.q.Walk(func(o *Operation) error {
 		fmt.Fprintf(fs, "%s[kind=%q];\n", o.ID, o.Spec.Kind())
 		for _, child := range f.q.Children(o.ID) {
 			fmt.Fprintf(fs, "%s->%s;\n", o.ID, child.ID)

--- a/query/plan/logical.go
+++ b/query/plan/logical.go
@@ -13,6 +13,7 @@ var RootUUID = NilUUID
 type LogicalPlanSpec struct {
 	Procedures map[ProcedureID]*Procedure
 	Order      []ProcedureID
+	Resources  query.ResourceManagement
 }
 
 func (lp *LogicalPlanSpec) Do(f func(pr *Procedure)) {
@@ -42,6 +43,7 @@ func (p *logicalPlanner) Plan(q *query.QuerySpec) (*LogicalPlanSpec, error) {
 	p.q = q
 	p.plan = &LogicalPlanSpec{
 		Procedures: make(map[ProcedureID]*Procedure),
+		Resources:  q.Resources,
 	}
 	err := q.Walk(p.walkQuery)
 	if err != nil {

--- a/query/plan/physical.go
+++ b/query/plan/physical.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"errors"
+	"math"
 	"time"
 
 	"github.com/influxdata/ifql/query"
@@ -100,6 +101,10 @@ func (p *planner) Plan(lp *LogicalPlanSpec, s Storage, now time.Time) (*PlanSpec
 	// Update concurrency quota
 	if p.plan.Resources.ConcurrencyQuota == 0 {
 		p.plan.Resources.ConcurrencyQuota = len(p.plan.Procedures)
+	}
+	// Update memory quota
+	if p.plan.Resources.MemoryBytesQuota == 0 {
+		p.plan.Resources.MemoryBytesQuota = math.MaxInt64
 	}
 
 	return p.plan, nil

--- a/query/plan/physical_test.go
+++ b/query/plan/physical_test.go
@@ -19,6 +19,9 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 		{
 			name: "single push down",
 			lp: &plan.LogicalPlanSpec{
+				Resources: query.ResourceManagement{
+					ConcurrencyQuota: 1,
+				},
 				Procedures: map[plan.ProcedureID]*plan.Procedure{
 					plan.ProcedureIDFromOperationID("from"): {
 						ID: plan.ProcedureIDFromOperationID("from"),
@@ -60,6 +63,9 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 			},
 			pp: &plan.PlanSpec{
 				Now: time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC),
+				Resources: query.ResourceManagement{
+					ConcurrencyQuota: 1,
+				},
 				Bounds: plan.BoundsSpec{
 					Start: query.Time{
 						IsRelative: true,
@@ -120,6 +126,9 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 				},
 			},
 			pp: &plan.PlanSpec{
+				Resources: query.ResourceManagement{
+					ConcurrencyQuota: 1,
+				},
 				Now: time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC),
 				Bounds: plan.BoundsSpec{
 					Start: query.MinTime,
@@ -207,6 +216,9 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 			},
 			pp: &plan.PlanSpec{
 				Now: time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC),
+				Resources: query.ResourceManagement{
+					ConcurrencyQuota: 2,
+				},
 				Bounds: plan.BoundsSpec{
 					Start: query.Time{
 						IsRelative: true,
@@ -298,6 +310,9 @@ func TestPhysicalPlanner_Plan_PushDown_Branch(t *testing.T) {
 		Bounds: plan.BoundsSpec{
 			Start: query.MinTime,
 			Stop:  query.Now,
+		},
+		Resources: query.ResourceManagement{
+			ConcurrencyQuota: 2,
 		},
 		Procedures: map[plan.ProcedureID]*plan.Procedure{
 			fromID: {

--- a/query/plan/physical_test.go
+++ b/query/plan/physical_test.go
@@ -1,6 +1,7 @@
 package plan_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 			lp: &plan.LogicalPlanSpec{
 				Resources: query.ResourceManagement{
 					ConcurrencyQuota: 1,
+					MemoryBytesQuota: 10000,
 				},
 				Procedures: map[plan.ProcedureID]*plan.Procedure{
 					plan.ProcedureIDFromOperationID("from"): {
@@ -65,6 +67,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 				Now: time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC),
 				Resources: query.ResourceManagement{
 					ConcurrencyQuota: 1,
+					MemoryBytesQuota: 10000,
 				},
 				Bounds: plan.BoundsSpec{
 					Start: query.Time{
@@ -128,6 +131,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 			pp: &plan.PlanSpec{
 				Resources: query.ResourceManagement{
 					ConcurrencyQuota: 1,
+					MemoryBytesQuota: math.MaxInt64,
 				},
 				Now: time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC),
 				Bounds: plan.BoundsSpec{
@@ -218,6 +222,7 @@ func TestPhysicalPlanner_Plan(t *testing.T) {
 				Now: time.Date(2017, 8, 8, 0, 0, 0, 0, time.UTC),
 				Resources: query.ResourceManagement{
 					ConcurrencyQuota: 2,
+					MemoryBytesQuota: math.MaxInt64,
 				},
 				Bounds: plan.BoundsSpec{
 					Start: query.Time{
@@ -313,6 +318,7 @@ func TestPhysicalPlanner_Plan_PushDown_Branch(t *testing.T) {
 		},
 		Resources: query.ResourceManagement{
 			ConcurrencyQuota: 2,
+			MemoryBytesQuota: math.MaxInt64,
 		},
 		Procedures: map[plan.ProcedureID]*plan.Procedure{
 			fromID: {

--- a/query/query.go
+++ b/query/query.go
@@ -7,8 +7,9 @@ import (
 
 // QuerySpec specifies a query.
 type QuerySpec struct {
-	Operations []*Operation `json:"operations"`
-	Edges      []Edge       `json:"edges"`
+	Operations []*Operation       `json:"operations"`
+	Edges      []Edge             `json:"edges"`
+	Resources  ResourceManagement `json:"resources"`
 
 	sorted   []*Operation
 	children map[OperationID][]*Operation

--- a/query/resource_management.go
+++ b/query/resource_management.go
@@ -1,0 +1,62 @@
+package query
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// ResourceManagement defines how the query should consume avaliable resources.
+type ResourceManagement struct {
+	// Priority or the query.
+	// Queries with a lower value will move to the front of the priority queue.
+	// A zero value indicates the highest priority.
+	Priority Priority `json:"priority"`
+	// MaxCPUCores is the maximum number of cores this query may consume.
+	// A zero value indicates unlimited.
+	MaxCPUCores int64 `json:"max_cpu_cores"`
+	// MaxRAMBytes is the maximum number of bytes of RAM this query may consume.
+	// There is a small amount of overhead RAM being consumed by a query that will not be counted towards this limit.
+	// A zero value indicates unlimited.
+	MaxRAMBytes int64 `json:"max_ram_bytes"`
+}
+
+// Priority is an integer that represents the query priority.
+// Any positive 32bit integer value may be used.
+// Special constants are provided to represent the extreme high and low priorities.
+type Priority int32
+
+const (
+	// High is the highest possible priority = 0
+	High Priority = 0
+	// Low is the lowest possible priority = MaxInt32
+	Low Priority = math.MaxInt32
+)
+
+func (p Priority) MarshalText() ([]byte, error) {
+	switch p {
+	case Low:
+		return []byte("low"), nil
+	case High:
+		return []byte("high"), nil
+	default:
+		return []byte(strconv.FormatInt(int64(p), 10)), nil
+	}
+}
+
+func (p *Priority) UnmarshalText(txt []byte) error {
+	switch s := string(txt); s {
+	case "low":
+		*p = Low
+	case "high":
+		*p = High
+	default:
+		i, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return errors.Wrap(err, "invalid priority, must be an integer or 'low','high'")
+		}
+		*p = Priority(i)
+	}
+	return nil
+}

--- a/query/resource_management.go
+++ b/query/resource_management.go
@@ -13,13 +13,13 @@ type ResourceManagement struct {
 	// Queries with a lower value will move to the front of the priority queue.
 	// A zero value indicates the highest priority.
 	Priority Priority `json:"priority"`
-	// MaxCPUCores is the maximum number of cores this query may consume.
+	// ConcurrencyQuota is the number of concurrency workers allowed to process this query.
+	// A zero value indicates the planner can pick the optimal concurrency.
+	ConcurrencyQuota int `json:"concurrency_quota"`
+	// MemoryBytesQuota is the number of bytes of RAM this query may consume.
+	// There is a small amount of overhead memory being consumed by a query that will not be counted towards this limit.
 	// A zero value indicates unlimited.
-	MaxCPUCores int64 `json:"max_cpu_cores"`
-	// MaxRAMBytes is the maximum number of bytes of RAM this query may consume.
-	// There is a small amount of overhead RAM being consumed by a query that will not be counted towards this limit.
-	// A zero value indicates unlimited.
-	MaxRAMBytes int64 `json:"max_ram_bytes"`
+	MemoryBytesQuota int64 `json:"memory_bytes_quota"`
 }
 
 // Priority is an integer that represents the query priority.


### PR DESCRIPTION
This PR introduces a new structure on the QuerySpec that defines the how the query should manage its resources.

The ResourceManagement is designed such that the default zero value represents an query that has the highest priority and unlimited resources.

TODO
- [x] Add flags to iflqd to specify server resource limits.

Fixes #166


Three options are provided as part of the type:

```go
// Priority or the query.
// Queries with a lower value will move to the front of the priority queue.
// A zero value indicates the highest priority.
Priority Priority `json:"priority"`

// ConcurrencyQuota is the number of concurrency workers allowed to process this query.
// A zero value indicates the planner can pick the optimal concurrency.
ConcurrencyQuota int `json:"concurrency_quota"`

// MemoryBytesQuota is the number of bytes of RAM this query may consume.
// There is a small amount of overhead memory being consumed by a query that will not be counted towards this limit.
// A zero value indicates unlimited.
MemoryBytesQuota int64 `json:"memory_bytes_quota"`
```
