### PR TITLE
Change plan testing level so it more isolated

### DIFF
--- a/functions/count.go
+++ b/functions/count.go
@@ -55,12 +55,13 @@ func (s *CountProcedureSpec) PushDownRule() plan.PushDownRule {
 	return plan.PushDownRule{
 		Root:    FromKind,
 		Through: nil,
-		Match: func(root *plan.Procedure) bool {
-			selectSpec := root.Spec.(*FromProcedureSpec)
+		Match: func(spec plan.ProcedureSpec) bool {
+			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.GroupingSet
 		},
 	}
 }
+
 func (s *CountProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {
 	selectSpec := root.Spec.(*FromProcedureSpec)
 	if selectSpec.AggregateSet {

--- a/functions/first.go
+++ b/functions/first.go
@@ -63,8 +63,8 @@ func (s *FirstProcedureSpec) PushDownRule() plan.PushDownRule {
 	return plan.PushDownRule{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{GroupKind, LimitKind, FilterKind},
-		Match: func(pr *plan.Procedure) bool {
-			selectSpec := pr.Spec.(*FromProcedureSpec)
+		Match: func(spec plan.ProcedureSpec) bool {
+			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.AggregateSet
 		},
 	}

--- a/functions/group.go
+++ b/functions/group.go
@@ -119,8 +119,8 @@ func (s *GroupProcedureSpec) PushDownRule() plan.PushDownRule {
 	return plan.PushDownRule{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{LimitKind, RangeKind, FilterKind},
-		Match: func(root *plan.Procedure) bool {
-			selectSpec := root.Spec.(*FromProcedureSpec)
+		Match: func(spec plan.ProcedureSpec) bool {
+			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.AggregateSet
 		},
 	}

--- a/functions/last.go
+++ b/functions/last.go
@@ -64,8 +64,8 @@ func (s *LastProcedureSpec) PushDownRule() plan.PushDownRule {
 	return plan.PushDownRule{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{GroupKind, LimitKind, FilterKind},
-		Match: func(pr *plan.Procedure) bool {
-			selectSpec := pr.Spec.(*FromProcedureSpec)
+		Match: func(spec plan.ProcedureSpec) bool {
+			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.AggregateSet
 		},
 	}
@@ -96,6 +96,7 @@ func (s *LastProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Proc
 	selectSpec.DescendingSet = true
 	selectSpec.Descending = true
 }
+
 func (s *LastProcedureSpec) Copy() plan.ProcedureSpec {
 	ns := new(LastProcedureSpec)
 	ns.UseRowTime = s.UseRowTime

--- a/functions/range_test.go
+++ b/functions/range_test.go
@@ -29,198 +29,45 @@ func TestRangeOperation_Marshaling(t *testing.T) {
 	querytest.OperationMarshalingTestHelper(t, data, op)
 }
 
-func TestRange_PushDown_Single(t *testing.T) {
-	lp := &plan.LogicalPlanSpec{
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			plan.ProcedureIDFromOperationID("from"): {
-				ID: plan.ProcedureIDFromOperationID("from"),
-				Spec: &functions.FromProcedureSpec{
-					Database: "mydb",
-				},
-				Parents:  nil,
-				Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
-			},
-			plan.ProcedureIDFromOperationID("range"): {
-				ID: plan.ProcedureIDFromOperationID("range"),
-				Spec: &functions.RangeProcedureSpec{
-					Bounds: plan.BoundsSpec{
-						Start: query.Time{
-							Relative:   -1 * time.Hour,
-							IsRelative: true,
-						},
-						Stop: query.Time{
-							Absolute: time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC),
-						},
-					},
-				},
-				Parents: []plan.ProcedureID{
-					(plan.ProcedureIDFromOperationID("from")),
-				},
-				Children: nil,
-			},
-		},
-		Order: []plan.ProcedureID{
-			plan.ProcedureIDFromOperationID("from"),
-			plan.ProcedureIDFromOperationID("range"),
-		},
-	}
-
-	want := &plan.PlanSpec{
+func TestRange_PushDown(t *testing.T) {
+	spec := &functions.RangeProcedureSpec{
 		Bounds: plan.BoundsSpec{
-			Start: query.Time{
-				Relative:   -1 * time.Hour,
-				IsRelative: true,
-			},
-			Stop: query.Time{
-				Absolute: time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC),
-			},
+			Stop: query.Now,
 		},
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			plan.ProcedureIDFromOperationID("from"): {
-				ID: plan.ProcedureIDFromOperationID("from"),
-				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
-					BoundsSet: true,
-					Bounds: plan.BoundsSpec{
-						Start: query.Time{
-							Relative:   -1 * time.Hour,
-							IsRelative: true,
-						},
-						Stop: query.Time{
-							Absolute: time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC),
-						},
-					},
-				},
-				Children: []plan.ProcedureID{},
+	}
+	root := &plan.Procedure{
+		Spec: new(functions.FromProcedureSpec),
+	}
+	want := &plan.Procedure{
+		Spec: &functions.FromProcedureSpec{
+			BoundsSet: true,
+			Bounds: plan.BoundsSpec{
+				Stop: query.Now,
 			},
-		},
-		Results: []plan.ProcedureID{
-			(plan.ProcedureIDFromOperationID("from")),
-		},
-		Order: []plan.ProcedureID{
-			plan.ProcedureIDFromOperationID("from"),
 		},
 	}
 
-	plantest.PhysicalPlanTestHelper(t, lp, want)
+	plantest.PhysicalPlan_PushDown_TestHelper(t, spec, root, false, want)
 }
-
-func TestRange_PushDown_Branch(t *testing.T) {
-	lp := &plan.LogicalPlanSpec{
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			plan.ProcedureIDFromOperationID("from"): {
-				ID: plan.ProcedureIDFromOperationID("from"),
-				Spec: &functions.FromProcedureSpec{
-					Database: "mydb",
-				},
-				Parents: nil,
-				Children: []plan.ProcedureID{
-					plan.ProcedureIDFromOperationID("rangeA"),
-					plan.ProcedureIDFromOperationID("rangeB"),
-				},
-			},
-			plan.ProcedureIDFromOperationID("rangeA"): {
-				ID: plan.ProcedureIDFromOperationID("rangeA"),
-				Spec: &functions.RangeProcedureSpec{
-					Bounds: plan.BoundsSpec{
-						Start: query.Time{
-							Relative:   -1 * time.Hour,
-							IsRelative: true,
-						},
-						Stop: query.Time{
-							Absolute: time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC),
-						},
-					},
-				},
-				Parents: []plan.ProcedureID{
-					(plan.ProcedureIDFromOperationID("from")),
-				},
-				Children: nil,
-			},
-			plan.ProcedureIDFromOperationID("rangeB"): {
-				ID: plan.ProcedureIDFromOperationID("rangeB"),
-				Spec: &functions.RangeProcedureSpec{
-					Bounds: plan.BoundsSpec{
-						Start: query.Time{
-							Relative:   -10 * time.Hour,
-							IsRelative: true,
-						},
-						Stop: query.Time{
-							Absolute: time.Date(2007, 10, 10, 0, 0, 0, 0, time.UTC),
-						},
-					},
-				},
-				Parents: []plan.ProcedureID{
-					(plan.ProcedureIDFromOperationID("from")),
-				},
-				Children: nil,
-			},
-		},
-		Order: []plan.ProcedureID{
-			plan.ProcedureIDFromOperationID("from"),
-			plan.ProcedureIDFromOperationID("rangeA"),
-			plan.ProcedureIDFromOperationID("rangeB"), // rangeB is last so it will be duplicated
-		},
-	}
-
-	fromID := plan.ProcedureIDFromOperationID("from")
-	fromIDDup := plan.ProcedureIDForDuplicate(fromID)
-	want := &plan.PlanSpec{
+func TestRange_PushDown_Duplicate(t *testing.T) {
+	spec := &functions.RangeProcedureSpec{
 		Bounds: plan.BoundsSpec{
-			Start: query.Time{
-				Relative:   -10 * time.Hour,
-				IsRelative: true,
-			},
-			Stop: query.Time{
-				Absolute: time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC),
-			},
-		},
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			fromID: {
-				ID: fromID,
-				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
-					BoundsSet: true,
-					Bounds: plan.BoundsSpec{
-						Start: query.Time{
-							Relative:   -1 * time.Hour,
-							IsRelative: true,
-						},
-						Stop: query.Time{
-							Absolute: time.Date(2017, 10, 10, 0, 0, 0, 0, time.UTC),
-						},
-					},
-				},
-				Children: []plan.ProcedureID{},
-			},
-			fromIDDup: {
-				ID: fromIDDup,
-				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
-					BoundsSet: true,
-					Bounds: plan.BoundsSpec{
-						Start: query.Time{
-							Relative:   -10 * time.Hour,
-							IsRelative: true,
-						},
-						Stop: query.Time{
-							Absolute: time.Date(2007, 10, 10, 0, 0, 0, 0, time.UTC),
-						},
-					},
-				},
-				Parents:  []plan.ProcedureID{},
-				Children: []plan.ProcedureID{},
-			},
-		},
-		Results: []plan.ProcedureID{
-			fromID,
-			fromIDDup,
-		},
-		Order: []plan.ProcedureID{
-			fromID,
-			fromIDDup,
+			Stop: query.Now,
 		},
 	}
+	root := &plan.Procedure{
+		Spec: &functions.FromProcedureSpec{
+			BoundsSet: true,
+			Bounds: plan.BoundsSpec{
+				Start: query.MinTime,
+				Stop:  query.Now,
+			},
+		},
+	}
+	want := &plan.Procedure{
+		// Expect the duplicate has been reset to zero values
+		Spec: new(functions.FromProcedureSpec),
+	}
 
-	plantest.PhysicalPlanTestHelper(t, lp, want)
+	plantest.PhysicalPlan_PushDown_TestHelper(t, spec, root, true, want)
 }

--- a/functions/sum.go
+++ b/functions/sum.go
@@ -56,8 +56,8 @@ func (s *SumProcedureSpec) PushDownRule() plan.PushDownRule {
 	return plan.PushDownRule{
 		Root:    FromKind,
 		Through: nil,
-		Match: func(root *plan.Procedure) bool {
-			selectSpec := root.Spec.(*FromProcedureSpec)
+		Match: func(spec plan.ProcedureSpec) bool {
+			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.GroupingSet
 		},
 	}

--- a/functions/sum_test.go
+++ b/functions/sum_test.go
@@ -38,166 +38,45 @@ func BenchmarkSum(b *testing.B) {
 	)
 }
 
-func TestSum_PushDown_Single(t *testing.T) {
-	lp := &plan.LogicalPlanSpec{
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			plan.ProcedureIDFromOperationID("select"): {
-				ID: plan.ProcedureIDFromOperationID("select"),
-				Spec: &functions.FromProcedureSpec{
-					Database: "mydb",
-				},
-				Parents:  nil,
-				Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
-			},
-			plan.ProcedureIDFromOperationID("range"): {
-				ID: plan.ProcedureIDFromOperationID("range"),
-				Spec: &functions.RangeProcedureSpec{
-					Bounds: plan.BoundsSpec{
-						Stop: query.Now,
-					},
-				},
-				Parents:  []plan.ProcedureID{plan.ProcedureIDFromOperationID("select")},
-				Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("sum")},
-			},
-			plan.ProcedureIDFromOperationID("sum"): {
-				ID:   plan.ProcedureIDFromOperationID("sum"),
-				Spec: &functions.SumProcedureSpec{},
-				Parents: []plan.ProcedureID{
-					(plan.ProcedureIDFromOperationID("range")),
-				},
-				Children: nil,
-			},
-		},
-		Order: []plan.ProcedureID{
-			plan.ProcedureIDFromOperationID("select"),
-			plan.ProcedureIDFromOperationID("range"),
-			plan.ProcedureIDFromOperationID("sum"),
-		},
-	}
+func TestSum_PushDown_Match(t *testing.T) {
+	spec := new(functions.SumProcedureSpec)
+	from := new(functions.FromProcedureSpec)
 
-	want := &plan.PlanSpec{
-		Bounds: plan.BoundsSpec{
-			Stop: query.Now,
-		},
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			plan.ProcedureIDFromOperationID("select"): {
-				ID: plan.ProcedureIDFromOperationID("select"),
-				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
-					BoundsSet: true,
-					Bounds: plan.BoundsSpec{
-						Stop: query.Now,
-					},
-					AggregateSet:  true,
-					AggregateType: "sum",
-				},
-				Children: []plan.ProcedureID{},
-			},
-		},
-		Results: []plan.ProcedureID{
-			(plan.ProcedureIDFromOperationID("select")),
-		},
-		Order: []plan.ProcedureID{
-			plan.ProcedureIDFromOperationID("select"),
-		},
-	}
+	// Should not match when an aggregate is set
+	from.GroupingSet = true
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, false)
 
-	plantest.PhysicalPlanTestHelper(t, lp, want)
+	// Should match when no aggregate is set
+	from.GroupingSet = false
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, true)
 }
 
-func TestSum_PushDown_Branch(t *testing.T) {
-	lp := &plan.LogicalPlanSpec{
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			plan.ProcedureIDFromOperationID("select"): {
-				ID: plan.ProcedureIDFromOperationID("select"),
-				Spec: &functions.FromProcedureSpec{
-					Database: "mydb",
-				},
-				Parents:  nil,
-				Children: []plan.ProcedureID{plan.ProcedureIDFromOperationID("range")},
-			},
-			plan.ProcedureIDFromOperationID("range"): {
-				ID: plan.ProcedureIDFromOperationID("range"),
-				Spec: &functions.RangeProcedureSpec{
-					Bounds: plan.BoundsSpec{
-						Stop: query.Now,
-					},
-				},
-				Parents: []plan.ProcedureID{plan.ProcedureIDFromOperationID("select")},
-				Children: []plan.ProcedureID{
-					plan.ProcedureIDFromOperationID("sum"),
-					plan.ProcedureIDFromOperationID("count"),
-				},
-			},
-			plan.ProcedureIDFromOperationID("sum"): {
-				ID:   plan.ProcedureIDFromOperationID("sum"),
-				Spec: &functions.SumProcedureSpec{},
-				Parents: []plan.ProcedureID{
-					(plan.ProcedureIDFromOperationID("select")),
-				},
-				Children: nil,
-			},
-			plan.ProcedureIDFromOperationID("count"): {
-				ID:   plan.ProcedureIDFromOperationID("count"),
-				Spec: &functions.CountProcedureSpec{},
-				Parents: []plan.ProcedureID{
-					(plan.ProcedureIDFromOperationID("select")),
-				},
-				Children: nil,
-			},
-		},
-		Order: []plan.ProcedureID{
-			plan.ProcedureIDFromOperationID("select"),
-			plan.ProcedureIDFromOperationID("range"),
-			plan.ProcedureIDFromOperationID("count"),
-			plan.ProcedureIDFromOperationID("sum"), // Sum is last so it will be duplicated
+func TestSum_PushDown(t *testing.T) {
+	spec := new(functions.SumProcedureSpec)
+	root := &plan.Procedure{
+		Spec: new(functions.FromProcedureSpec),
+	}
+	want := &plan.Procedure{
+		Spec: &functions.FromProcedureSpec{
+			AggregateSet:  true,
+			AggregateType: functions.SumKind,
 		},
 	}
 
-	selectID := plan.ProcedureIDFromOperationID("select")
-	selectIDDup := plan.ProcedureIDForDuplicate(selectID)
-	want := &plan.PlanSpec{
-		Bounds: plan.BoundsSpec{
-			Stop: query.Now,
-		},
-		Procedures: map[plan.ProcedureID]*plan.Procedure{
-			selectID: {
-				ID: selectID,
-				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
-					BoundsSet: true,
-					Bounds: plan.BoundsSpec{
-						Stop: query.Now,
-					},
-					AggregateSet:  true,
-					AggregateType: "count",
-				},
-				Children: []plan.ProcedureID{},
-			},
-			selectIDDup: {
-				ID: selectIDDup,
-				Spec: &functions.FromProcedureSpec{
-					Database:  "mydb",
-					BoundsSet: true,
-					Bounds: plan.BoundsSpec{
-						Stop: query.Now,
-					},
-					AggregateSet:  true,
-					AggregateType: "sum",
-				},
-				Parents:  []plan.ProcedureID{},
-				Children: []plan.ProcedureID{},
-			},
-		},
-		Results: []plan.ProcedureID{
-			selectID,
-			selectIDDup,
-		},
-		Order: []plan.ProcedureID{
-			selectID,
-			selectIDDup,
+	plantest.PhysicalPlan_PushDown_TestHelper(t, spec, root, false, want)
+}
+func TestSum_PushDown_Duplicate(t *testing.T) {
+	spec := new(functions.SumProcedureSpec)
+	root := &plan.Procedure{
+		Spec: &functions.FromProcedureSpec{
+			AggregateSet:  true,
+			AggregateType: functions.SumKind,
 		},
 	}
+	want := &plan.Procedure{
+		// Expect the duplicate has been reset to zero values
+		Spec: new(functions.FromProcedureSpec),
+	}
 
-	plantest.PhysicalPlanTestHelper(t, lp, want)
+	plantest.PhysicalPlan_PushDown_TestHelper(t, spec, root, true, want)
 }

--- a/query/plan/physical.go
+++ b/query/plan/physical.go
@@ -111,7 +111,7 @@ func (p *planner) pushDownAndSearch(pr *Procedure, rule PushDownRule, do func(pa
 		pp := p.plan.Procedures[parent]
 		pk := pp.Spec.Kind()
 		if pk == rule.Root {
-			if rule.Match == nil || rule.Match(pp) {
+			if rule.Match == nil || rule.Match(pp.Spec) {
 				do(pp, func() *Procedure { return p.duplicate(pp, false) })
 				matched = true
 			}

--- a/query/plan/procedure.go
+++ b/query/plan/procedure.go
@@ -60,7 +60,7 @@ type BoundedProcedureSpec interface {
 type PushDownRule struct {
 	Root    ProcedureKind
 	Through []ProcedureKind
-	Match   func(*Procedure) bool
+	Match   func(ProcedureSpec) bool
 }
 
 // ProcedureKind denotes the kind of operations.


### PR DESCRIPTION
Previously the tests in the functions package exercised the entire physical plan code. Small changes to that code would mean updating all functions tests. Now the tests are better "unit" tests, only testing their small bit in isolation.

FWIW Code coverage increases with this change, with less test code so I call that a win.