### PR TITLE
Add map function

### DIFF
--- a/functions/map.go
+++ b/functions/map.go
@@ -1,0 +1,252 @@
+package functions
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/influxdata/ifql/ast"
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/plan"
+	"github.com/pkg/errors"
+)
+
+const MapKind = "map"
+
+type MapOpSpec struct {
+	Fn *ast.ArrowFunctionExpression `json:"fn"`
+}
+
+func init() {
+	query.RegisterMethod(MapKind, createMapOpSpec)
+	query.RegisterOpSpec(MapKind, newMapOp)
+	plan.RegisterProcedureSpec(MapKind, newMapProcedure, MapKind)
+	execute.RegisterTransformation(MapKind, createMapTransformation)
+}
+
+func createMapOpSpec(args query.Arguments, a *query.Administration) (query.OperationSpec, error) {
+	f, err := args.GetRequiredFunction("fn")
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := f.Resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	return &MapOpSpec{
+		Fn: resolved,
+	}, nil
+}
+func newMapOp() query.OperationSpec {
+	return new(MapOpSpec)
+}
+
+func (s *MapOpSpec) Kind() query.OperationKind {
+	return MapKind
+}
+
+type MapProcedureSpec struct {
+	Fn *ast.ArrowFunctionExpression
+}
+
+func newMapProcedure(qs query.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*MapOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+
+	return &MapProcedureSpec{
+		Fn: spec.Fn,
+	}, nil
+}
+
+func (s *MapProcedureSpec) Kind() plan.ProcedureKind {
+	return MapKind
+}
+func (s *MapProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(MapProcedureSpec)
+	ns.Fn = s.Fn.Copy().(*ast.ArrowFunctionExpression)
+	return ns
+}
+
+func createMapTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*MapProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+	}
+	cache := execute.NewBlockBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, cache)
+	t, err := NewMapTransformation(d, cache, s)
+	if err != nil {
+		return nil, nil, err
+	}
+	return t, d, nil
+}
+
+type mapTransformation struct {
+	d     execute.Dataset
+	cache execute.BlockBuilderCache
+
+	references []execute.Reference
+	scope      execute.Scope
+	scopeCols  map[string]int
+	ces        map[execute.DataType]expressionOrError
+}
+
+func NewMapTransformation(d execute.Dataset, cache execute.BlockBuilderCache, spec *MapProcedureSpec) (*mapTransformation, error) {
+	if len(spec.Fn.Params) != 1 {
+		return nil, fmt.Errorf("map functions should only have a single parameter, got %v", spec.Fn.Params)
+	}
+	objectName := spec.Fn.Params[0].Name
+	references, err := execute.FindReferences(spec.Fn)
+	if err != nil {
+		return nil, err
+	}
+
+	valueRP := execute.Reference{objectName, "_value"}.Path()
+	types := make(map[execute.ReferencePath]execute.DataType, len(references))
+	for _, r := range references {
+		if len(r) != 2 {
+			return nil, fmt.Errorf("found invalid reference in the map function %q", r)
+		}
+		rp := r.Path()
+		if rp != valueRP {
+			types[rp] = execute.TString
+		}
+	}
+
+	ces := make(map[execute.DataType]expressionOrError, len(execute.ValueDataTypes))
+	for _, typ := range execute.ValueDataTypes {
+		types[valueRP] = typ
+		ce, err := execute.CompileExpression(spec.Fn, types)
+		ces[typ] = expressionOrError{
+			Err:  err,
+			Expr: ce,
+		}
+	}
+
+	return &mapTransformation{
+		d:          d,
+		cache:      cache,
+		references: references,
+		scope:      make(execute.Scope),
+		scopeCols:  make(map[string]int),
+		ces:        ces,
+	}, nil
+}
+
+func (t *mapTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) error {
+	return t.d.RetractBlock(execute.ToBlockKey(meta))
+}
+
+func (t *mapTransformation) Process(id execute.DatasetID, b execute.Block) error {
+	// Check that the function supports the col type.
+	cols := b.Cols()
+	valueIdx := execute.ValueIdx(cols)
+	valueCol := cols[valueIdx]
+	exprErr := t.ces[valueCol.Type]
+	if exprErr.Err != nil {
+		return errors.Wrapf(exprErr.Err, "expression does not support type %v", valueCol.Type)
+	}
+	ce := exprErr.Expr
+
+	builder, new := t.cache.BlockBuilder(b)
+	if new {
+		// Add columns to builder
+		for j, c := range cols {
+			if j == valueIdx {
+				builder.AddCol(execute.ColMeta{
+					Label: execute.ValueColLabel,
+					Type:  ce.Type(),
+				})
+				continue
+			}
+
+			builder.AddCol(c)
+			if c.IsTag && c.IsCommon {
+				builder.SetCommonString(j, b.Tags()[c.Label])
+			}
+		}
+	}
+
+	// Prepare scope
+	for j, c := range cols {
+		if c.Label == execute.ValueColLabel {
+			t.scopeCols["_value"] = valueIdx
+		} else {
+			for _, r := range t.references {
+				if r[1] == c.Label {
+					t.scopeCols[c.Label] = j
+					break
+				}
+			}
+		}
+	}
+
+	// Append modified rows
+	b.Times().DoTime(func(ts []execute.Time, rr execute.RowReader) {
+		for i := range ts {
+			for _, r := range t.references {
+				t.scope[r.Path()] = execute.ValueForRow(i, t.scopeCols[r[1]], rr)
+			}
+			v, err := ce.Eval(t.scope)
+			if err != nil {
+				log.Printf("failed to evaluate map expression: %v", err)
+				continue
+			}
+			for j, c := range cols {
+				if c.IsCommon {
+					continue
+				}
+				if j == valueIdx {
+					switch val := v.Value.(type) {
+					case bool:
+						builder.AppendBool(j, val)
+					case int64:
+						builder.AppendInt(j, val)
+					case uint64:
+						builder.AppendUInt(j, val)
+					case float64:
+						builder.AppendFloat(j, val)
+					case string:
+						builder.AppendString(j, val)
+					case execute.Time:
+						builder.AppendTime(j, val)
+					default:
+						execute.PanicUnknownType(v.Type)
+					}
+					continue
+				}
+				switch c.Type {
+				case execute.TBool:
+					builder.AppendBool(j, rr.AtBool(i, j))
+				case execute.TInt:
+					builder.AppendInt(j, rr.AtInt(i, j))
+				case execute.TUInt:
+					builder.AppendUInt(j, rr.AtUInt(i, j))
+				case execute.TFloat:
+					builder.AppendFloat(j, rr.AtFloat(i, j))
+				case execute.TString:
+					builder.AppendString(j, rr.AtString(i, j))
+				case execute.TTime:
+					builder.AppendTime(j, rr.AtTime(i, j))
+				default:
+					execute.PanicUnknownType(c.Type)
+				}
+			}
+		}
+	})
+	return nil
+}
+
+func (t *mapTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return t.d.UpdateWatermark(mark)
+}
+func (t *mapTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
+}
+func (t *mapTransformation) Finish(id execute.DatasetID, err error) {
+	t.d.Finish(err)
+}

--- a/functions/map_test.go
+++ b/functions/map_test.go
@@ -1,0 +1,267 @@
+package functions_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/ifql/ast"
+	"github.com/influxdata/ifql/functions"
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/execute/executetest"
+	"github.com/influxdata/ifql/query/querytest"
+)
+
+func TestMap_NewQuery(t *testing.T) {
+	tests := []querytest.NewQueryTestCase{
+		{
+			Name: "simple static map",
+			Raw:  `from(db:"mydb").map(fn: (r) => r._value + 1)`,
+			Want: &query.QuerySpec{
+				Operations: []*query.Operation{
+					{
+						ID: "from0",
+						Spec: &functions.FromOpSpec{
+							Database: "mydb",
+						},
+					},
+					{
+						ID: "map1",
+						Spec: &functions.MapOpSpec{
+							Fn: &ast.ArrowFunctionExpression{
+								Params: []*ast.Identifier{{Name: "r"}},
+								Body: &ast.BinaryExpression{
+									Operator: ast.AdditionOperator,
+									Left: &ast.MemberExpression{
+										Object: &ast.Identifier{
+											Name: "r",
+										},
+										Property: &ast.Identifier{Name: "_value"},
+									},
+									Right: &ast.IntegerLiteral{Value: 1},
+								},
+							},
+						},
+					},
+				},
+				Edges: []query.Edge{
+					{Parent: "from0", Child: "map1"},
+				},
+			},
+		},
+		{
+			Name: "resolve map",
+			Raw:  `var x = 2 from(db:"mydb").map(fn: (r) => r._value + x)`,
+			Want: &query.QuerySpec{
+				Operations: []*query.Operation{
+					{
+						ID: "from0",
+						Spec: &functions.FromOpSpec{
+							Database: "mydb",
+						},
+					},
+					{
+						ID: "map1",
+						Spec: &functions.MapOpSpec{
+							Fn: &ast.ArrowFunctionExpression{
+								Params: []*ast.Identifier{{Name: "r"}},
+								Body: &ast.BinaryExpression{
+									Operator: ast.AdditionOperator,
+									Left: &ast.MemberExpression{
+										Object: &ast.Identifier{
+											Name: "r",
+										},
+										Property: &ast.Identifier{Name: "_value"},
+									},
+									Right: &ast.IntegerLiteral{Value: 2},
+								},
+							},
+						},
+					},
+				},
+				Edges: []query.Edge{
+					{Parent: "from0", Child: "map1"},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			querytest.NewQueryTestHelper(t, tc)
+		})
+	}
+}
+
+func TestMapOperation_Marshaling(t *testing.T) {
+	data := []byte(`{
+		"id":"map",
+		"kind":"map",
+		"spec":{
+			"fn":{
+				"type": "ArrowFunctionExpression",
+				"params": [{"type":"Identifier","name":"r"}],
+				"body":{
+					"type":"BinaryExpression",
+					"operator": "-",
+					"left":{
+						"type":"MemberExpression",
+						"object": {
+							"type": "Identifier",
+							"name":"r"
+						},
+						"property": {"type":"StringLiteral","value":"_value"}
+					},
+					"right":{
+						"type":"FloatLiteral",
+						"value": 5.6
+					}
+				}
+			}
+		}
+	}`)
+	op := &query.Operation{
+		ID: "map",
+		Spec: &functions.MapOpSpec{
+			Fn: &ast.ArrowFunctionExpression{
+				Params: []*ast.Identifier{{Name: "r"}},
+				Body: &ast.BinaryExpression{
+					Operator: ast.SubtractionOperator,
+					Left: &ast.MemberExpression{
+						Object: &ast.Identifier{
+							Name: "r",
+						},
+						Property: &ast.StringLiteral{Value: "_value"},
+					},
+					Right: &ast.FloatLiteral{Value: 5.6},
+				},
+			},
+		},
+	}
+	querytest.OperationMarshalingTestHelper(t, data, op)
+}
+func TestMap_Process(t *testing.T) {
+	testCases := []struct {
+		name string
+		spec *functions.MapProcedureSpec
+		data []execute.Block
+		want []*executetest.Block
+	}{
+		{
+			name: `_value+5`,
+			spec: &functions.MapProcedureSpec{
+				Fn: &ast.ArrowFunctionExpression{
+					Params: []*ast.Identifier{{Name: "r"}},
+					Body: &ast.BinaryExpression{
+						Operator: ast.AdditionOperator,
+						Left: &ast.MemberExpression{
+							Object: &ast.Identifier{
+								Name: "r",
+							},
+							Property: &ast.StringLiteral{Value: "_value"},
+						},
+						Right: &ast.FloatLiteral{
+							Value: 5,
+						},
+					},
+				},
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "time", Type: execute.TTime},
+					{Label: "value", Type: execute.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "time", Type: execute.TTime},
+					{Label: "value", Type: execute.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 6.0},
+					{execute.Time(2), 11.0},
+				},
+			}},
+		},
+		{
+			name: `_value*_value`,
+			spec: &functions.MapProcedureSpec{
+				Fn: &ast.ArrowFunctionExpression{
+					Params: []*ast.Identifier{{Name: "r"}},
+					Body: &ast.BinaryExpression{
+						Operator: ast.MultiplicationOperator,
+						Left: &ast.MemberExpression{
+							Object: &ast.Identifier{
+								Name: "r",
+							},
+							Property: &ast.StringLiteral{Value: "_value"},
+						},
+						Right: &ast.MemberExpression{
+							Object: &ast.Identifier{
+								Name: "r",
+							},
+							Property: &ast.StringLiteral{Value: "_value"},
+						},
+					},
+				},
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "time", Type: execute.TTime},
+					{Label: "value", Type: execute.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "time", Type: execute.TTime},
+					{Label: "value", Type: execute.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 36.0},
+				},
+			}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			executetest.ProcessTestHelper(
+				t,
+				tc.data,
+				tc.want,
+				func(d execute.Dataset, c execute.BlockBuilderCache) execute.Transformation {
+					f, err := functions.NewMapTransformation(d, c, tc.spec)
+					if err != nil {
+						t.Fatal(err)
+					}
+					return f
+				},
+			)
+		})
+	}
+}

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -370,6 +370,7 @@ func (q *Query) setResults(r []execute.Result) {
 // compile transitions the query into the Compiling state.
 func (q *Query) compile() {
 	q.mu.Lock()
+
 	q.compilingSpan, q.compilingCtx = StartSpanFromContext(q.parentCtx, "compiling")
 	compilingGauge.Inc()
 


### PR DESCRIPTION
This PR depends on #167 

The `map` function applies an arrow function to all records of a table.
The `map` function is the implementation of the `eval` TICKscript node.

TODO
- [ ] How to mutate tags vs values? (This is going to be answered in #182)
- [x] Add tests


  