### PR TITLE
Add integral function

### DIFF
--- a/functions/integral.go
+++ b/functions/integral.go
@@ -1,0 +1,205 @@
+package functions
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/plan"
+)
+
+const IntegralKind = "integral"
+
+type IntegralOpSpec struct {
+	Unit query.Duration `json:"unit"`
+}
+
+func init() {
+	query.RegisterMethod(IntegralKind, createIntegralOpSpec)
+	query.RegisterOpSpec(IntegralKind, newIntegralOp)
+	plan.RegisterProcedureSpec(IntegralKind, newIntegralProcedure, IntegralKind)
+	execute.RegisterTransformation(IntegralKind, createIntegralTransformation)
+}
+
+func createIntegralOpSpec(args query.Arguments, a *query.Administration) (query.OperationSpec, error) {
+	spec := new(IntegralOpSpec)
+
+	if unit, ok, err := args.GetDuration("unit"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Unit = unit
+	} else {
+		//Default is 1s
+		spec.Unit = query.Duration(time.Second)
+	}
+
+	return spec, nil
+}
+
+func newIntegralOp() query.OperationSpec {
+	return new(IntegralOpSpec)
+}
+
+func (s *IntegralOpSpec) Kind() query.OperationKind {
+	return IntegralKind
+}
+
+type IntegralProcedureSpec struct {
+	Unit query.Duration `json:"unit"`
+}
+
+func newIntegralProcedure(qs query.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*IntegralOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+
+	return &IntegralProcedureSpec{
+		Unit: spec.Unit,
+	}, nil
+}
+
+func (s *IntegralProcedureSpec) Kind() plan.ProcedureKind {
+	return IntegralKind
+}
+func (s *IntegralProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(IntegralProcedureSpec)
+	*ns = *s
+	return ns
+}
+
+func createIntegralTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*IntegralProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+	}
+	cache := execute.NewBlockBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, cache)
+	t := NewIntegralTransformation(d, cache, s, a.Bounds())
+	return t, d, nil
+}
+
+type integralTransformation struct {
+	d      execute.Dataset
+	cache  execute.BlockBuilderCache
+	bounds execute.Bounds
+
+	unit time.Duration
+}
+
+func NewIntegralTransformation(d execute.Dataset, cache execute.BlockBuilderCache, spec *IntegralProcedureSpec, bounds execute.Bounds) *integralTransformation {
+	return &integralTransformation{
+		d:      d,
+		cache:  cache,
+		bounds: bounds,
+		unit:   time.Duration(spec.Unit),
+	}
+}
+
+func (t *integralTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) error {
+	return t.d.RetractBlock(execute.ToBlockKey(meta))
+}
+
+func (t *integralTransformation) Process(id execute.DatasetID, b execute.Block) error {
+	builder, new := t.cache.BlockBuilder(blockMetadata{
+		bounds: t.bounds,
+		tags:   b.Tags(),
+	})
+	if new {
+		cols := b.Cols()
+		for j, c := range cols {
+			switch c.Kind {
+			case execute.TimeColKind:
+				builder.AddCol(c)
+			case execute.TagColKind:
+				if c.Common {
+					builder.AddCol(c)
+					builder.SetCommonString(j, b.Tags()[c.Label])
+				}
+			case execute.ValueColKind:
+				dc := c
+				// Integral always results in a float64
+				dc.Type = execute.TFloat
+				builder.AddCol(dc)
+			}
+		}
+	}
+	cols := b.Cols()
+	integrals := make([]*integral, len(cols))
+	for j, c := range cols {
+		if c.IsValue() {
+			in := newIntegral(t.unit)
+			integrals[j] = in
+		}
+	}
+
+	b.Times().DoTime(func(ts []execute.Time, rr execute.RowReader) {
+		for j, in := range integrals {
+			if in == nil {
+				continue
+			}
+			for i, t := range ts {
+				in.updateFloat(t, rr.AtFloat(i, j))
+			}
+		}
+	})
+
+	timeIdx := execute.TimeIdx(cols)
+	builder.AppendTime(timeIdx, b.Bounds().Stop)
+
+	for j, in := range integrals {
+		if in == nil {
+			continue
+		}
+		builder.AppendFloat(j, in.value())
+	}
+
+	return nil
+}
+
+func (t *integralTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return t.d.UpdateWatermark(mark)
+}
+func (t *integralTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
+}
+func (t *integralTransformation) Finish(id execute.DatasetID, err error) {
+	t.d.Finish(err)
+}
+
+func newIntegral(unit time.Duration) *integral {
+	return &integral{
+		first: true,
+		unit:  float64(unit),
+	}
+}
+
+type integral struct {
+	first bool
+	unit  float64
+
+	pFloatValue float64
+	pTime       execute.Time
+
+	sum float64
+}
+
+func (in *integral) value() float64 {
+	return in.sum
+}
+
+func (in *integral) updateFloat(t execute.Time, v float64) {
+	if in.first {
+		in.pTime = t
+		in.pFloatValue = v
+		in.first = false
+		return
+	}
+
+	elapsed := float64(t-in.pTime) / in.unit
+	in.sum += 0.5 * (v + in.pFloatValue) * elapsed
+
+	in.pTime = t
+	in.pFloatValue = v
+}

--- a/functions/integral_test.go
+++ b/functions/integral_test.go
@@ -1,0 +1,212 @@
+package functions_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/ifql/functions"
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/execute/executetest"
+	"github.com/influxdata/ifql/query/querytest"
+)
+
+func TestIntegralOperation_Marshaling(t *testing.T) {
+	data := []byte(`{"id":"integral","kind":"integral","spec":{"unit":"1m"}}`)
+	op := &query.Operation{
+		ID: "integral",
+		Spec: &functions.IntegralOpSpec{
+			Unit: query.Duration(time.Minute),
+		},
+	}
+	querytest.OperationMarshalingTestHelper(t, data, op)
+}
+
+func TestIntegral_PassThrough(t *testing.T) {
+	executetest.TransformationPassThroughTestHelper(t, func(d execute.Dataset, c execute.BlockBuilderCache) execute.Transformation {
+		s := functions.NewIntegralTransformation(
+			d,
+			c,
+			&functions.IntegralProcedureSpec{},
+			execute.Bounds{},
+		)
+		return s
+	})
+}
+
+func TestIntegral_Process(t *testing.T) {
+	testCases := []struct {
+		name   string
+		spec   *functions.IntegralProcedureSpec
+		bounds execute.Bounds
+		data   []execute.Block
+		want   []*executetest.Block
+	}{
+		{
+			name: "float",
+			spec: &functions.IntegralProcedureSpec{
+				Unit: 1,
+			},
+			bounds: execute.Bounds{
+				Start: 1,
+				Stop:  3,
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 1.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), 1.5},
+				},
+			}},
+		},
+		{
+			name: "float with units",
+			spec: &functions.IntegralProcedureSpec{
+				Unit: query.Duration(time.Second),
+			},
+			bounds: execute.Bounds{
+				Start: execute.Time(1 * time.Second),
+				Stop:  execute.Time(4 * time.Second),
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: execute.Time(1 * time.Second),
+					Stop:  execute.Time(4 * time.Second),
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1 * time.Second), 2.0},
+					{execute.Time(3 * time.Second), 1.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: execute.Time(1 * time.Second),
+					Stop:  execute.Time(4 * time.Second),
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(4 * time.Second), 3.0},
+				},
+			}},
+		},
+		{
+			name: "float with tags",
+			spec: &functions.IntegralProcedureSpec{
+				Unit: 1,
+			},
+			bounds: execute.Bounds{
+				Start: 1,
+				Stop:  3,
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					{Label: "t", Type: execute.TString, Kind: execute.TagColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0, "a"},
+					{execute.Time(2), 1.0, "b"},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), 1.5},
+				},
+			}},
+		},
+		{
+			name: "float with multiple values",
+			spec: &functions.IntegralProcedureSpec{
+				Unit: 1,
+			},
+			bounds: execute.Bounds{
+				Start: 1,
+				Stop:  5,
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  5,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "x", Type: execute.TFloat, Kind: execute.ValueColKind},
+					{Label: "y", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0, 20.0},
+					{execute.Time(2), 1.0, 10.0},
+					{execute.Time(3), 2.0, 20.0},
+					{execute.Time(4), 1.0, 10.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  5,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "x", Type: execute.TFloat, Kind: execute.ValueColKind},
+					{Label: "y", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(5), 4.5, 45.0},
+				},
+			}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			executetest.ProcessTestHelper(
+				t,
+				tc.data,
+				tc.want,
+				func(d execute.Dataset, c execute.BlockBuilderCache) execute.Transformation {
+					return functions.NewIntegralTransformation(d, c, tc.spec, tc.bounds)
+				},
+			)
+		})
+	}
+}


### PR DESCRIPTION
Adds the integral function as implemented here https://github.com/influxdata/influxdb/blob/master/query/functions.go#L1020

NOTE that the interpolation logic is not present in this implementation as that should be an external step in the process. This probably means when we rewrite integral queries to IFQL we will need to add an interpolate step.

