### PR TITLE
Update filter to be able to push down multiple filter expressions

### DIFF
--- a/functions/count.go
+++ b/functions/count.go
@@ -44,15 +44,15 @@ func (s *CountProcedureSpec) Copy() plan.ProcedureSpec {
 	return new(CountProcedureSpec)
 }
 
-func (s *CountProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *CountProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: nil,
 		Match: func(spec plan.ProcedureSpec) bool {
 			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.GroupingSet
 		},
-	}
+	}}
 }
 
 func (s *CountProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {

--- a/functions/count_test.go
+++ b/functions/count_test.go
@@ -92,11 +92,11 @@ func TestCount_PushDown_Match(t *testing.T) {
 
 	// Should not match when an aggregate is set
 	from.GroupingSet = true
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, false)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{false})
 
 	// Should match when no aggregate is set
 	from.GroupingSet = false
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, true)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{true})
 }
 
 func TestCount_PushDown(t *testing.T) {

--- a/functions/first.go
+++ b/functions/first.go
@@ -65,15 +65,15 @@ func newFirstProcedure(qs query.OperationSpec, pa plan.Administration) (plan.Pro
 func (s *FirstProcedureSpec) Kind() plan.ProcedureKind {
 	return FirstKind
 }
-func (s *FirstProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *FirstProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{GroupKind, LimitKind, FilterKind},
 		Match: func(spec plan.ProcedureSpec) bool {
 			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.AggregateSet
 		},
-	}
+	}}
 }
 
 func (s *FirstProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {

--- a/functions/first_test.go
+++ b/functions/first_test.go
@@ -78,11 +78,11 @@ func TestFirst_PushDown_Match(t *testing.T) {
 
 	// Should not match when an aggregate is set
 	from.AggregateSet = true
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, false)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{false})
 
 	// Should match when no aggregate is set
 	from.AggregateSet = false
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, true)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{true})
 }
 
 func TestFirst_PushDown(t *testing.T) {

--- a/functions/group.go
+++ b/functions/group.go
@@ -96,15 +96,15 @@ func (s *GroupProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
-func (s *GroupProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *GroupProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{LimitKind, RangeKind, FilterKind},
 		Match: func(spec plan.ProcedureSpec) bool {
 			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.AggregateSet
 		},
-	}
+	}}
 }
 
 func (s *GroupProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {

--- a/functions/last.go
+++ b/functions/last.go
@@ -65,15 +65,15 @@ func (s *LastProcedureSpec) Kind() plan.ProcedureKind {
 	return LastKind
 }
 
-func (s *LastProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *LastProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{GroupKind, LimitKind, FilterKind},
 		Match: func(spec plan.ProcedureSpec) bool {
 			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.AggregateSet
 		},
-	}
+	}}
 }
 
 func (s *LastProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {

--- a/functions/last_test.go
+++ b/functions/last_test.go
@@ -80,11 +80,11 @@ func TestLast_PushDown_Match(t *testing.T) {
 
 	// Should not match when an aggregate is set
 	from.AggregateSet = true
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, false)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{false})
 
 	// Should match when no aggregate is set
 	from.AggregateSet = false
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, true)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{true})
 }
 
 func TestLast_PushDown(t *testing.T) {

--- a/functions/limit.go
+++ b/functions/limit.go
@@ -71,11 +71,11 @@ func (s *LimitProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
-func (s *LimitProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *LimitProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{GroupKind, RangeKind, FilterKind},
-	}
+	}}
 }
 func (s *LimitProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {
 	selectSpec := root.Spec.(*FromProcedureSpec)

--- a/functions/range.go
+++ b/functions/range.go
@@ -77,11 +77,11 @@ func (s *RangeProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
-func (s *RangeProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *RangeProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: []plan.ProcedureKind{GroupKind, LimitKind, FilterKind},
-	}
+	}}
 }
 func (s *RangeProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {
 	selectSpec := root.Spec.(*FromProcedureSpec)

--- a/functions/sum.go
+++ b/functions/sum.go
@@ -45,15 +45,15 @@ func (s *SumProcedureSpec) Copy() plan.ProcedureSpec {
 	return new(SumProcedureSpec)
 }
 
-func (s *SumProcedureSpec) PushDownRule() plan.PushDownRule {
-	return plan.PushDownRule{
+func (s *SumProcedureSpec) PushDownRules() []plan.PushDownRule {
+	return []plan.PushDownRule{{
 		Root:    FromKind,
 		Through: nil,
 		Match: func(spec plan.ProcedureSpec) bool {
 			selectSpec := spec.(*FromProcedureSpec)
 			return !selectSpec.GroupingSet
 		},
-	}
+	}}
 }
 func (s *SumProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Procedure) {
 	selectSpec := root.Spec.(*FromProcedureSpec)

--- a/functions/sum_test.go
+++ b/functions/sum_test.go
@@ -44,11 +44,11 @@ func TestSum_PushDown_Match(t *testing.T) {
 
 	// Should not match when an aggregate is set
 	from.GroupingSet = true
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, false)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{false})
 
 	// Should match when no aggregate is set
 	from.GroupingSet = false
-	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, true)
+	plantest.PhysicalPlan_PushDown_Match_TestHelper(t, spec, from, []bool{true})
 }
 
 func TestSum_PushDown(t *testing.T) {

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -179,6 +179,7 @@ func (c *Controller) run() {
 				q.plan = p
 				q.concurrency = p.Resources.ConcurrencyQuota
 				q.memory = p.Resources.MemoryBytesQuota
+				//log.Println("plan", plan.Formatted(q.plan))
 			}
 
 			// Check if we have enough resources

--- a/query/plan/physical.go
+++ b/query/plan/physical.go
@@ -75,10 +75,12 @@ func (p *planner) Plan(lp *LogicalPlanSpec, s Storage, now time.Time) (*PlanSpec
 		for _, id := range order {
 			pr := p.plan.Procedures[id]
 			if pd, ok := pr.Spec.(PushDownProcedureSpec); ok {
-				rule := pd.PushDownRule()
-				if p.pushDownAndSearch(pr, rule, pd.PushDown) {
-					if err := p.removeProcedure(pr); err != nil {
-						return nil, errors.Wrap(err, "failed to remove procedure")
+				rules := pd.PushDownRules()
+				for _, rule := range rules {
+					if p.pushDownAndSearch(pr, rule, pd.PushDown) {
+						if err := p.removeProcedure(pr); err != nil {
+							return nil, errors.Wrap(err, "failed to remove procedure")
+						}
 					}
 				}
 			}

--- a/query/plan/plantest/physical.go
+++ b/query/plan/plantest/physical.go
@@ -8,13 +8,18 @@ import (
 	"github.com/influxdata/ifql/query/plan"
 )
 
-func PhysicalPlan_PushDown_Match_TestHelper(t *testing.T, spec plan.PushDownProcedureSpec, matchSpec plan.ProcedureSpec, want bool) {
+func PhysicalPlan_PushDown_Match_TestHelper(t *testing.T, spec plan.PushDownProcedureSpec, matchSpec plan.ProcedureSpec, want []bool) {
 	t.Helper()
 
-	rule := spec.PushDownRule()
-	got := rule.Match(matchSpec)
-	if got != want {
-		t.Errorf("unexpected push down rule matching: got: %t want: %t", got, want)
+	rules := spec.PushDownRules()
+	if len(want) != len(rules) {
+		t.Fatalf("unexpected number of rules, want:%d got:%d", len(want), len(rules))
+	}
+	for i, rule := range rules {
+		got := rule.Match(matchSpec)
+		if got != want[i] {
+			t.Errorf("unexpected push down rule matching: got: %t want: %t", got, want[i])
+		}
 	}
 }
 

--- a/query/plan/procedure.go
+++ b/query/plan/procedure.go
@@ -52,7 +52,7 @@ type ProcedureSpec interface {
 }
 
 type PushDownProcedureSpec interface {
-	PushDownRule() PushDownRule
+	PushDownRules() []PushDownRule
 	PushDown(root *Procedure, dup func() *Procedure)
 }
 


### PR DESCRIPTION
Now if a multiple filter expressions exist they can be pushed down into the same expression.

Example:
```
from(db:"telegraf")
    .filter(fn: (r) => r._measurement == "cpu")
    .filter(fn: (r) => r._field == "usage_idle")
```

This gets pushed down to become:

```
from(db:"telegraf")
    .filter(fn: (r) => r._measurement == "cpu" and r._field == "usage_idle")
```


This is only implemented if both filter functions are pure expressions and not statements, as that will require being able to call functions from the row_fn compiled code. 