### PR TITLE
Fix pushdown when procedure has siblings

### DIFF
--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -170,6 +170,7 @@ func (c *Controller) run() {
 					q.setErr(errors.Wrap(err, "failed to create logical plan"))
 					continue
 				}
+				//log.Println("logical plan", plan.Formatted(lp))
 
 				p, err := c.pplanner.Plan(lp, nil, q.now)
 				if err != nil {


### PR DESCRIPTION
Fixes a bug where if a procedure was pushed down its siblings would be dropped from the plan.

As an aside, the push down logic is getting quite complex, we need to be thinking about maybe implementing one of the known query planning algorithms to provide a good structure for these kinds of changes in the future.