### PR TITLE
Add yield function

### DIFF
--- a/cmd/ifql/main.go
+++ b/cmd/ifql/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
+	"sort"
 
 	"github.com/influxdata/ifql"
 	"github.com/influxdata/ifql/query/execute"
@@ -126,8 +127,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	for _, r := range results {
+	names := make([]string, 0, len(results))
+	for name := range results {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		r := results[name]
 		blocks := r.Blocks()
+		fmt.Println("Result:", name)
 		err := blocks.Do(func(b execute.Block) error {
 			execute.NewFormatter(b, nil).WriteTo(os.Stdout)
 			return nil

--- a/functions/yield.go
+++ b/functions/yield.go
@@ -1,0 +1,78 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/plan"
+	"github.com/influxdata/ifql/semantic"
+)
+
+const YieldKind = "yield"
+
+type YieldOpSpec struct {
+	Name string `json:"name"`
+}
+
+var yieldSignature = semantic.FunctionSignature{
+	Params: map[string]semantic.Type{
+		query.TableParameter: query.TableObjectType,
+		"name":               semantic.String,
+	},
+	ReturnType:   semantic.Nil,
+	PipeArgument: query.TableParameter,
+}
+
+func init() {
+	query.RegisterFunction(YieldKind, createYieldOpSpec, yieldSignature)
+	query.RegisterOpSpec(YieldKind, newYieldOp)
+	plan.RegisterProcedureSpec(YieldKind, newYieldProcedure, YieldKind)
+}
+
+func createYieldOpSpec(args query.Arguments, a *query.Administration) (query.OperationSpec, error) {
+	if err := a.AddParentFromArgs(args); err != nil {
+		return nil, err
+	}
+
+	spec := new(YieldOpSpec)
+
+	name, err := args.GetRequiredString("name")
+	if err != nil {
+		return nil, err
+	}
+	spec.Name = name
+
+	return spec, nil
+}
+
+func newYieldOp() query.OperationSpec {
+	return new(YieldOpSpec)
+}
+
+func (s *YieldOpSpec) Kind() query.OperationKind {
+	return YieldKind
+}
+
+type YieldProcedureSpec struct {
+	Name string `json:"name"`
+}
+
+func newYieldProcedure(qs query.OperationSpec, _ plan.Administration) (plan.ProcedureSpec, error) {
+	if spec, ok := qs.(*YieldOpSpec); ok {
+		return &YieldProcedureSpec{Name: spec.Name}, nil
+	}
+
+	return nil, fmt.Errorf("invalid spec type %T", qs)
+}
+
+func (s *YieldProcedureSpec) Kind() plan.ProcedureKind {
+	return YieldKind
+}
+
+func (s *YieldProcedureSpec) Copy() plan.ProcedureSpec {
+	return &YieldProcedureSpec{Name: s.Name}
+}
+
+func (s *YieldProcedureSpec) YieldName() string {
+	return s.Name
+}

--- a/query/execute/result.go
+++ b/query/execute/result.go
@@ -2,6 +2,8 @@ package execute
 
 import (
 	"sync"
+
+	"github.com/influxdata/ifql/query/plan"
 )
 
 type Result interface {
@@ -24,7 +26,7 @@ type resultMessage struct {
 	err   error
 }
 
-func newResultSink() *resultSink {
+func newResultSink(plan.YieldSpec) *resultSink {
 	return &resultSink{
 		// TODO(nathanielc): Currently this buffer needs to be big enough hold all result blocks :(
 		blocks:   make(chan resultMessage, 1000),

--- a/query/plan/procedure.go
+++ b/query/plan/procedure.go
@@ -60,6 +60,10 @@ type BoundedProcedureSpec interface {
 	TimeBounds() BoundsSpec
 }
 
+type YieldProcedureSpec interface {
+	YieldName() string
+}
+
 type ParentAwareProcedureSpec interface {
 	ParentChanged(old, new ProcedureID)
 }


### PR DESCRIPTION
Fixes #143 
The yield function specifies which results to produce. If a query  DAG has a a single leaf then its implied that the single leaf is the operation to yield. Otherwise if a query has more than one leaf node, then it must specify which results to produce.

The yield function only has a `name` argument to name the result. This allows the specific results to be referenced by name instead of an index that is dependent on read order of the DAG. It matches well with keyword arguments in IFQL as a language.

Example:

```javascript
cpu = from(db:"telegraf")
    |> filter(fn: (r) => r._measurement == "cpu" and r._field == "usage_idle" and r.cpu == "cpu-total")
    |> range(start: -1m)

cpu
    |> mean()
    |> yield(name:"mean")

cpu
    |> count()
    |> yield(name:"count")

```

By using a yield function we have flexibility to add more arguments to yield for future use. For example in the context of a REPL you may want strict error handling such that any error on any record returns an error, but in the context of a background query you may want it to only log errors caused by individual records. Yield provides a user interface for these kinds of decisions.

This PR implements the minimal functionality to provide named results.