### PR TITLE
Add state count and state duration functions

### DIFF
--- a/functions/state_tracking.go
+++ b/functions/state_tracking.go
@@ -1,0 +1,302 @@
+package functions
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/plan"
+	"github.com/influxdata/ifql/semantic"
+	"github.com/pkg/errors"
+)
+
+const StateTrackingKind = "stateTracking"
+
+type StateTrackingOpSpec struct {
+	Fn            *semantic.FunctionExpression `json:"fn"`
+	CountLabel    string                       `json:"count_label"`
+	DurationLabel string                       `json:"duration_label"`
+	DurationUnit  query.Duration               `json:"duration_unit"`
+}
+
+var stateTrackingSignature = query.DefaultFunctionSignature()
+
+func init() {
+	stateTrackingSignature.Params["fn"] = semantic.Function
+	stateTrackingSignature.Params["countLabel"] = semantic.String
+	stateTrackingSignature.Params["durationLabel"] = semantic.String
+	stateTrackingSignature.Params["durationUnit"] = semantic.Duration
+
+	query.RegisterFunction(StateTrackingKind, createStateTrackingOpSpec, stateTrackingSignature)
+	query.RegisterBuiltIn("state-tracking", stateTrackingBuiltin)
+	query.RegisterOpSpec(StateTrackingKind, newStateTrackingOp)
+	plan.RegisterProcedureSpec(StateTrackingKind, newStateTrackingProcedure, StateTrackingKind)
+	execute.RegisterTransformation(StateTrackingKind, createStateTrackingTransformation)
+}
+
+var stateTrackingBuiltin = `
+// stateCount computes the number of consecutive records in a given state.
+// The state is defined via the function fn. For each consecutive point for
+// which the expression evaluates as true, the state count will be incremented
+// When a point evaluates as false, the state count is reset.
+//
+// The state count will be added as an additional column to each record. If the
+// expression evaluates as false, the value will be -1. If the expression
+// generates an error during evaluation, the point is discarded, and does not
+// affect the state count.
+stateCount = (fn, label="stateCount", table=<-) =>
+	stateTracking(table:table, countLabel:label, fn:fn)
+
+// stateDuration computes the duration of a given state.
+// The state is defined via the function fn. For each consecutive point for
+// which the expression evaluates as true, the state duration will be
+// incremented by the duration between points. When a point evaluates as false,
+// the state duration is reset.
+//
+// The state duration will be added as an additional column to each record. If the
+// expression evaluates as false, the value will be -1. If the expression
+// generates an error during evaluation, the point is discarded, and does not
+// affect the state duration.
+//
+// Note that as the first point in the given state has no previous point, its
+// state duration will be 0.
+//
+// The duration is represented as an integer in the units specified.
+stateDuration = (fn, label="stateDuration", unit=1s, table=<-) =>
+	stateTracking(table:table, durationLabel:label, fn:fn, durationUnit:unit)
+`
+
+func createStateTrackingOpSpec(args query.Arguments, a *query.Administration) (query.OperationSpec, error) {
+	if err := a.AddParentFromArgs(args); err != nil {
+		return nil, err
+	}
+
+	f, err := args.GetRequiredFunction("fn")
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := f.Resolve()
+	if err != nil {
+		return nil, err
+	}
+
+	spec := &StateTrackingOpSpec{
+		Fn:           resolved,
+		DurationUnit: query.Duration(time.Second),
+	}
+
+	if label, ok, err := args.GetString("countLabel"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.CountLabel = label
+	}
+	if label, ok, err := args.GetString("durationLabel"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.DurationLabel = label
+	}
+	if unit, ok, err := args.GetDuration("durationUnit"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.DurationUnit = unit
+	}
+
+	if spec.DurationLabel != "" && spec.DurationUnit <= 0 {
+		return nil, errors.New("state tracking duration unit must be greater than zero")
+	}
+	return spec, nil
+}
+
+func newStateTrackingOp() query.OperationSpec {
+	return new(StateTrackingOpSpec)
+}
+
+func (s *StateTrackingOpSpec) Kind() query.OperationKind {
+	return StateTrackingKind
+}
+
+type StateTrackingProcedureSpec struct {
+	Fn *semantic.FunctionExpression
+	CountLabel,
+	DurationLabel string
+	DurationUnit query.Duration
+}
+
+func newStateTrackingProcedure(qs query.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*StateTrackingOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+
+	return &StateTrackingProcedureSpec{
+		Fn:            spec.Fn,
+		CountLabel:    spec.CountLabel,
+		DurationLabel: spec.DurationLabel,
+		DurationUnit:  spec.DurationUnit,
+	}, nil
+}
+
+func (s *StateTrackingProcedureSpec) Kind() plan.ProcedureKind {
+	return StateTrackingKind
+}
+func (s *StateTrackingProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(StateTrackingProcedureSpec)
+	*ns = *s
+
+	ns.Fn = s.Fn.Copy().(*semantic.FunctionExpression)
+
+	return ns
+}
+
+func createStateTrackingTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*StateTrackingProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+	}
+	cache := execute.NewBlockBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, cache)
+	t, err := NewStateTrackingTransformation(d, cache, s)
+	if err != nil {
+		return nil, nil, err
+	}
+	return t, d, nil
+}
+
+type stateTrackingTransformation struct {
+	d     execute.Dataset
+	cache execute.BlockBuilderCache
+
+	fn *execute.RowPredicateFn
+
+	countLabel,
+	durationLabel string
+
+	durationUnit int64
+
+	colMap []int
+}
+
+func NewStateTrackingTransformation(d execute.Dataset, cache execute.BlockBuilderCache, spec *StateTrackingProcedureSpec) (*stateTrackingTransformation, error) {
+	fn, err := execute.NewRowPredicateFn(spec.Fn)
+	if err != nil {
+		return nil, err
+	}
+	return &stateTrackingTransformation{
+		d:             d,
+		cache:         cache,
+		fn:            fn,
+		countLabel:    spec.CountLabel,
+		durationLabel: spec.DurationLabel,
+		durationUnit:  int64(spec.DurationUnit),
+	}, nil
+}
+
+func (t *stateTrackingTransformation) RetractBlock(id execute.DatasetID, meta execute.BlockMetadata) error {
+	return t.d.RetractBlock(execute.ToBlockKey(meta))
+}
+
+func (t *stateTrackingTransformation) Process(id execute.DatasetID, b execute.Block) error {
+	// Prepare the functions for the column types.
+	cols := b.Cols()
+	err := t.fn.Prepare(cols)
+	if err != nil {
+		// TODO(nathanielc): Should we not fail the query for failed compilation?
+		return err
+	}
+
+	builder, new := t.cache.BlockBuilder(b)
+	if !new {
+		return fmt.Errorf("received duplicate block bounds: %v tags: %v", b.Bounds(), b.Tags())
+	}
+
+	// Add tag columns to builder
+	for _, c := range cols {
+		nj := builder.AddCol(c)
+		if c.Common {
+			builder.SetCommonString(nj, b.Tags()[c.Label])
+		}
+	}
+
+	l := len(cols)
+	if cap(t.colMap) < l {
+		t.colMap = make([]int, l)
+		for j := range t.colMap {
+			t.colMap[j] = j
+		}
+	} else {
+		t.colMap = t.colMap[:l]
+	}
+
+	var countCol, durationCol = -1, -1
+
+	// Add new value colums
+	if t.countLabel != "" {
+		countCol = builder.AddCol(execute.ColMeta{
+			Label: t.countLabel,
+			Type:  execute.TInt,
+			Kind:  execute.ValueColKind,
+		})
+	}
+	if t.durationLabel != "" {
+		durationCol = builder.AddCol(execute.ColMeta{
+			Label: t.durationLabel,
+			Type:  execute.TInt,
+			Kind:  execute.ValueColKind,
+		})
+	}
+
+	var (
+		startTime execute.Time
+		count,
+		duration int64
+		inState bool
+	)
+
+	// Append modified rows
+	b.Times().DoTime(func(ts []execute.Time, rr execute.RowReader) {
+		for i, tm := range ts {
+			match, err := t.fn.Eval(i, rr)
+			if err != nil {
+				log.Printf("failed to evaluate state count expression: %v", err)
+				continue
+			}
+			if !match {
+				count = -1
+				duration = -1
+				inState = false
+			} else {
+				if !inState {
+					startTime = tm
+					duration = 0
+					count = 0
+					inState = true
+				}
+				if t.durationUnit > 0 {
+					duration = int64(tm-startTime) / t.durationUnit
+				}
+				count++
+			}
+			execute.AppendRowForCols(i, rr, builder, cols, t.colMap)
+			if countCol > 0 {
+				builder.AppendInt(countCol, count)
+			}
+			if durationCol > 0 {
+				builder.AppendInt(durationCol, duration)
+			}
+		}
+	})
+	return nil
+}
+
+func (t *stateTrackingTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return t.d.UpdateWatermark(mark)
+}
+func (t *stateTrackingTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
+}
+func (t *stateTrackingTransformation) Finish(id execute.DatasetID, err error) {
+	t.d.Finish(err)
+}

--- a/functions/state_tracking_test.go
+++ b/functions/state_tracking_test.go
@@ -1,0 +1,201 @@
+package functions_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/ifql/ast"
+	"github.com/influxdata/ifql/functions"
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/execute/executetest"
+	"github.com/influxdata/ifql/query/querytest"
+	"github.com/influxdata/ifql/semantic"
+)
+
+func TestStateTrackingOperation_Marshaling(t *testing.T) {
+	data := []byte(`{"id":"id","kind":"stateTracking","spec":{"count_label":"c","duration_label":"d","duration_unit":"1m"}}`)
+	op := &query.Operation{
+		ID: "id",
+		Spec: &functions.StateTrackingOpSpec{
+			CountLabel:    "c",
+			DurationLabel: "d",
+			DurationUnit:  query.Duration(time.Minute),
+		},
+	}
+	querytest.OperationMarshalingTestHelper(t, data, op)
+}
+
+func TestStateTracking_Process(t *testing.T) {
+	gt5 := &semantic.FunctionExpression{
+		Params: []*semantic.FunctionParam{{Key: &semantic.Identifier{Name: "r"}}},
+		Body: &semantic.BinaryExpression{
+			Operator: ast.GreaterThanOperator,
+			Left: &semantic.MemberExpression{
+				Object:   &semantic.IdentifierExpression{Name: "r"},
+				Property: "_value",
+			},
+			Right: &semantic.FloatLiteral{Value: 5.0},
+		},
+	}
+	testCases := []struct {
+		name string
+		spec *functions.StateTrackingProcedureSpec
+		data []execute.Block
+		want []*executetest.Block
+	}{
+		{
+			name: "one block",
+			spec: &functions.StateTrackingProcedureSpec{
+				CountLabel:    "count",
+				DurationLabel: "duration",
+				DurationUnit:  1,
+				Fn:            gt5,
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 1.0},
+					{execute.Time(3), 6.0},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.0},
+					{execute.Time(6), 1.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					{Label: "count", Type: execute.TInt, Kind: execute.ValueColKind},
+					{Label: "duration", Type: execute.TInt, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0, int64(-1), int64(-1)},
+					{execute.Time(2), 1.0, int64(-1), int64(-1)},
+					{execute.Time(3), 6.0, int64(1), int64(0)},
+					{execute.Time(4), 7.0, int64(2), int64(1)},
+					{execute.Time(5), 8.0, int64(3), int64(2)},
+					{execute.Time(6), 1.0, int64(-1), int64(-1)},
+				},
+			}},
+		},
+		{
+			name: "only duration",
+			spec: &functions.StateTrackingProcedureSpec{
+				DurationLabel: "duration",
+				DurationUnit:  1,
+				Fn:            gt5,
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 1.0},
+					{execute.Time(3), 6.0},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.0},
+					{execute.Time(6), 1.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					{Label: "duration", Type: execute.TInt, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0, int64(-1)},
+					{execute.Time(2), 1.0, int64(-1)},
+					{execute.Time(3), 6.0, int64(0)},
+					{execute.Time(4), 7.0, int64(1)},
+					{execute.Time(5), 8.0, int64(2)},
+					{execute.Time(6), 1.0, int64(-1)},
+				},
+			}},
+		},
+		{
+			name: "only count",
+			spec: &functions.StateTrackingProcedureSpec{
+				CountLabel: "count",
+				Fn:         gt5,
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 1.0},
+					{execute.Time(3), 6.0},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.0},
+					{execute.Time(6), 1.0},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					{Label: "count", Type: execute.TInt, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0, int64(-1)},
+					{execute.Time(2), 1.0, int64(-1)},
+					{execute.Time(3), 6.0, int64(1)},
+					{execute.Time(4), 7.0, int64(2)},
+					{execute.Time(5), 8.0, int64(3)},
+					{execute.Time(6), 1.0, int64(-1)},
+				},
+			}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			executetest.ProcessTestHelper(
+				t,
+				tc.data,
+				tc.want,
+				func(d execute.Dataset, c execute.BlockBuilderCache) execute.Transformation {
+					tx, err := functions.NewStateTrackingTransformation(d, c, tc.spec)
+					if err != nil {
+						t.Fatal(err)
+					}
+					return tx
+				},
+			)
+		})
+	}
+}

--- a/query/execute/block.go
+++ b/query/execute/block.go
@@ -175,6 +175,29 @@ func AppendRow(i int, rr RowReader, builder BlockBuilder, colMap []int) {
 	}
 }
 
+// AppendRowForCols appends a single row from rr onto builder for the specified cols.
+// The colMap is a map of builder columnm index to rr column index.
+func AppendRowForCols(i int, rr RowReader, builder BlockBuilder, cols []ColMeta, colMap []int) {
+	for j, c := range cols {
+		switch c.Type {
+		case TBool:
+			builder.AppendBool(j, rr.AtBool(i, colMap[j]))
+		case TInt:
+			builder.AppendInt(j, rr.AtInt(i, colMap[j]))
+		case TUInt:
+			builder.AppendUInt(j, rr.AtUInt(i, colMap[j]))
+		case TFloat:
+			builder.AppendFloat(j, rr.AtFloat(i, colMap[j]))
+		case TString:
+			builder.AppendString(j, rr.AtString(i, colMap[j]))
+		case TTime:
+			builder.AppendTime(j, rr.AtTime(i, colMap[j]))
+		default:
+			PanicUnknownType(c.Type)
+		}
+	}
+}
+
 // AddTags add columns to the builder for the given tags.
 // It is assumed that all tags are common to all rows of this block.
 func AddTags(t Tags, b BlockBuilder) {


### PR DESCRIPTION
The behavior is the same as in Kapacitor.

Only a single stateTracking node is implemented which does the both stateCount and stateDuration operations. 