### PR TITLE
Add percentile function with exact and approximate implementations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,10 +8,13 @@
   version = "0.10.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/apex/log"
-  packages = [".","handlers/cli"]
-  revision = "0296d6eb16bb28f8a0c55668affcf4876dc269be"
-  version = "v1.0.0"
+  packages = [
+    ".",
+    "handlers/cli"
+  ]
+  revision = "ff0f66940b829dc66c81dad34746d4349b83eb9e"
 
 [[projects]]
   branch = "master"
@@ -26,8 +29,21 @@
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
+  name = "github.com/fatih/color"
+  packages = ["."]
+  revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
+  version = "v1.5.0"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["codec","gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys","types"]
+  packages = [
+    "codec",
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys",
+    "types"
+  ]
   revision = "100ba4e885062801d56799d78530b73b178a78f3"
   version = "v0.4"
 
@@ -40,7 +56,12 @@
 [[projects]]
   branch = "master"
   name = "github.com/gonum/blas"
-  packages = [".","blas64","native","native/internal/math32"]
+  packages = [
+    ".",
+    "blas64",
+    "native",
+    "native/internal/math32"
+  ]
   revision = "37e82626499e1df7c54aeaba0959fd6e7e8dc1e4"
 
 [[projects]]
@@ -52,37 +73,61 @@
 [[projects]]
   branch = "master"
   name = "github.com/gonum/internal"
-  packages = ["asm/f32","asm/f64"]
+  packages = [
+    "asm/f32",
+    "asm/f64"
+  ]
   revision = "e57e4534cf9b3b00ef6c0175f59d8d2d34f60914"
 
 [[projects]]
   branch = "master"
   name = "github.com/gonum/lapack"
-  packages = [".","lapack64","native"]
+  packages = [
+    ".",
+    "lapack64",
+    "native"
+  ]
   revision = "5ed4b826becd1807e09377508f51756586d1a98c"
 
 [[projects]]
   branch = "master"
   name = "github.com/gonum/mathext"
-  packages = [".","internal/amos","internal/cephes","internal/gonum"]
+  packages = [
+    ".",
+    "internal/amos",
+    "internal/cephes",
+    "internal/gonum"
+  ]
   revision = "0b9a913d27c42216782103ce3773136730e1535f"
 
 [[projects]]
   branch = "master"
   name = "github.com/gonum/matrix"
-  packages = [".","mat64"]
+  packages = [
+    ".",
+    "mat64"
+  ]
   revision = "dd6034299e4242c9f0ea36735e6d4264dfcb3f9f"
 
 [[projects]]
   branch = "master"
   name = "github.com/gonum/stat"
-  packages = [".","distuv"]
+  packages = [
+    ".",
+    "distuv"
+  ]
   revision = "40602ac931a7ab7f72cb1eff5ce1753a2d28d345"
 
 [[projects]]
   branch = "master"
   name = "github.com/google/go-cmp"
-  packages = ["cmp","cmp/cmpopts","cmp/internal/diff","cmp/internal/function","cmp/internal/value"]
+  packages = [
+    "cmp",
+    "cmp/cmpopts",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value"
+  ]
   revision = "d5735f74713c51f7450a43d0a98d41ce2c1db3cb"
 
 [[projects]]
@@ -99,21 +144,61 @@
 
 [[projects]]
   name = "github.com/goreleaser/archive"
-  packages = [".","tar","zip"]
+  packages = [
+    ".",
+    "tar",
+    "zip"
+  ]
   revision = "caa5f3f5742eb0535631e94fa5e171c74c0144b7"
   version = "v1.0.0"
 
 [[projects]]
   name = "github.com/goreleaser/goreleaser"
-  packages = [".","checksum","config","context","goreleaserlib","internal/archiveformat","internal/buildtarget","internal/client","internal/ext","internal/git","internal/linux","internal/name","pipeline","pipeline/archive","pipeline/brew","pipeline/build","pipeline/changelog","pipeline/checksums","pipeline/cleandist","pipeline/defaults","pipeline/docker","pipeline/env","pipeline/fpm","pipeline/git","pipeline/release","pipeline/snapcraft"]
+  packages = [
+    ".",
+    "checksum",
+    "config",
+    "context",
+    "goreleaserlib",
+    "internal/archiveformat",
+    "internal/buildtarget",
+    "internal/client",
+    "internal/ext",
+    "internal/git",
+    "internal/linux",
+    "internal/name",
+    "pipeline",
+    "pipeline/archive",
+    "pipeline/brew",
+    "pipeline/build",
+    "pipeline/changelog",
+    "pipeline/checksums",
+    "pipeline/cleandist",
+    "pipeline/defaults",
+    "pipeline/docker",
+    "pipeline/env",
+    "pipeline/fpm",
+    "pipeline/git",
+    "pipeline/release",
+    "pipeline/snapcraft"
+  ]
   revision = "adc2d7d4c572af20cc20290db48b664f12c158bb"
   version = "v0.35.7"
 
 [[projects]]
   name = "github.com/influxdata/influxdb"
-  packages = ["models","pkg/escape"]
+  packages = [
+    "models",
+    "pkg/escape"
+  ]
   revision = "2d474a3089bcfce6b472779be9470a1f0ef3d5e4"
   version = "v1.3.7"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/influxdata/tdigest"
+  packages = ["."]
+  revision = "617b83f940fd9acd207f712561a8a0590277fb38"
 
 [[projects]]
   branch = "master"
@@ -130,7 +215,12 @@
 [[projects]]
   branch = "master"
   name = "github.com/influxdata/yarpc"
-  packages = [".","codes","status","yarpcproto"]
+  packages = [
+    ".",
+    "codes",
+    "status",
+    "yarpcproto"
+  ]
   revision = "036268cdec22b7074cd6d50cc6d7315c667063c7"
 
 [[projects]]
@@ -140,9 +230,24 @@
   version = "v1.3.0"
 
 [[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
+
+[[projects]]
   branch = "master"
   name = "github.com/mattn/go-zglob"
-  packages = [".","fastwalk"]
+  packages = [
+    ".",
+    "fastwalk"
+  ]
   revision = "4b74c24375b3b1ee226867156e01996f4e19a8d6"
 
 [[projects]]
@@ -154,12 +259,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/mna/pigeon"
-  packages = [".","ast","builder"]
+  packages = [
+    ".",
+    "ast",
+    "builder"
+  ]
   revision = "904fede4321f9aae0e347d296f56035410375fed"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [".","ext","log"]
+  packages = [
+    ".",
+    "ext",
+    "log"
+  ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
@@ -171,7 +284,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
@@ -184,13 +300,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "1bab55dd05dbff384524a6a1c99006d9eb5f139b"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
@@ -201,7 +324,21 @@
 
 [[projects]]
   name = "github.com/uber/jaeger-client-go"
-  packages = [".","config","internal/baggage","internal/baggage/remote","internal/spanlog","log","rpcmetrics","thrift-gen/agent","thrift-gen/baggage","thrift-gen/jaeger","thrift-gen/sampling","thrift-gen/zipkincore","utils"]
+  packages = [
+    ".",
+    "config",
+    "internal/baggage",
+    "internal/baggage/remote",
+    "internal/spanlog",
+    "log",
+    "rpcmetrics",
+    "thrift-gen/agent",
+    "thrift-gen/baggage",
+    "thrift-gen/jaeger",
+    "thrift-gen/sampling",
+    "thrift-gen/zipkincore",
+    "utils"
+  ]
   revision = "0ce42f3f87dae4f5ba84bdc60c99a908db419cb8"
   version = "v2.10.0"
 
@@ -220,13 +357,19 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "01c190206fbdffa42f334f4b2bf2220f50e64920"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal"
+  ]
   revision = "9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402"
 
 [[projects]]
@@ -237,13 +380,30 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/tools"
-  packages = ["go/ast/astutil","imports"]
+  packages = [
+    "go/ast/astutil",
+    "imports"
+  ]
   revision = "e531a2a1c15f94033f6fa87666caeb19a688175f"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -256,6 +416,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "21cb3d46b26a5f7eeb75f991da4a8ef60e0cf113e4025afc95b1a532e514cf5e"
+  inputs-digest = "a7deb7039500ef615c52906accd19280fc42008713bc6e3a92793e7f3e7e8569"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/functions/percentile.go
+++ b/functions/percentile.go
@@ -1,0 +1,260 @@
+package functions
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/plan"
+	"github.com/influxdata/ifql/semantic"
+	"github.com/influxdata/tdigest"
+	"github.com/pkg/errors"
+)
+
+const PercentileKind = "percentile"
+const ExactPercentileKind = "exact-percentile"
+
+type PercentileOpSpec struct {
+	Percentile  float64 `json:"percentile"`
+	Compression float64 `json:"compression"`
+	Exact       bool    `json:"exact"`
+}
+
+var percentileSignature = query.DefaultFunctionSignature()
+
+func init() {
+	percentileSignature.Params["p"] = semantic.Float
+
+	query.RegisterFunction(PercentileKind, createPercentileOpSpec, percentileSignature)
+	query.RegisterBuiltIn("percentile", percentileBuiltin)
+
+	query.RegisterOpSpec(PercentileKind, newPercentileOp)
+	plan.RegisterProcedureSpec(PercentileKind, newPercentileProcedure, PercentileKind)
+	execute.RegisterTransformation(PercentileKind, createPercentileTransformation)
+	execute.RegisterTransformation(ExactPercentileKind, createExactPercentileTransformation)
+}
+
+var percentileBuiltin = `
+// median returns the 50th percentile.
+// By default an approximate percentile is computed, this can be disabled by passing exact:true.
+// Using the exact method requires that the entire data set can fit in memory.
+median = (exact=false, compression=0.0, table=<-) => percentile(table:table, p:0.5, exact:exact, compression:compression)
+`
+
+func createPercentileOpSpec(args query.Arguments, a *query.Administration) (query.OperationSpec, error) {
+	if err := a.AddParentFromArgs(args); err != nil {
+		return nil, err
+	}
+
+	spec := new(PercentileOpSpec)
+	p, err := args.GetRequiredFloat("p")
+	if err != nil {
+		return nil, err
+	}
+	spec.Percentile = p
+
+	if spec.Percentile < 0 || spec.Percentile > 1 {
+		return nil, errors.New("percentile must be between 0 and 1.")
+	}
+
+	if c, ok, err := args.GetFloat("compression"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Compression = c
+	}
+
+	if exact, ok, err := args.GetBool("exact"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Exact = exact
+	}
+
+	if spec.Compression > 0 && spec.Exact {
+		return nil, errors.New("cannot specify both compression and exact.")
+	}
+
+	// Set default Compression if not exact
+	if !spec.Exact && spec.Compression == 0 {
+		spec.Compression = 1000
+	}
+
+	return spec, nil
+}
+
+func newPercentileOp() query.OperationSpec {
+	return new(PercentileOpSpec)
+}
+
+func (s *PercentileOpSpec) Kind() query.OperationKind {
+	return PercentileKind
+}
+
+type PercentileProcedureSpec struct {
+	Percentile  float64 `json:"percentile"`
+	Compression float64 `json:"compression"`
+}
+
+func (s *PercentileProcedureSpec) Kind() plan.ProcedureKind {
+	return PercentileKind
+}
+func (s *PercentileProcedureSpec) Copy() plan.ProcedureSpec {
+	return &PercentileProcedureSpec{
+		Percentile:  s.Percentile,
+		Compression: s.Compression,
+	}
+}
+
+type ExactPercentileProcedureSpec struct {
+	Percentile float64 `json:"percentile"`
+}
+
+func (s *ExactPercentileProcedureSpec) Kind() plan.ProcedureKind {
+	return ExactPercentileKind
+}
+func (s *ExactPercentileProcedureSpec) Copy() plan.ProcedureSpec {
+	return &ExactPercentileProcedureSpec{Percentile: s.Percentile}
+}
+
+func newPercentileProcedure(qs query.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*PercentileOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+	if spec.Exact {
+		return &ExactPercentileProcedureSpec{
+			Percentile: spec.Percentile,
+		}, nil
+	}
+	return &PercentileProcedureSpec{
+		Percentile:  spec.Percentile,
+		Compression: spec.Compression,
+	}, nil
+}
+
+type PercentileAgg struct {
+	Quantile,
+	Compression float64
+
+	digest *tdigest.TDigest
+}
+
+func createPercentileTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	ps, ok := spec.(*PercentileProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+	}
+	agg := &PercentileAgg{
+		Quantile:    ps.Percentile,
+		Compression: ps.Compression,
+	}
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), agg, a.Allocator())
+	return t, d, nil
+}
+
+func (a *PercentileAgg) reset() {
+	a.digest = tdigest.NewWithCompression(a.Compression)
+}
+func (a *PercentileAgg) NewBoolAgg() execute.DoBoolAgg {
+	return nil
+}
+
+func (a *PercentileAgg) NewIntAgg() execute.DoIntAgg {
+	return nil
+}
+
+func (a *PercentileAgg) NewUIntAgg() execute.DoUIntAgg {
+	return nil
+}
+
+func (a *PercentileAgg) NewFloatAgg() execute.DoFloatAgg {
+	a.reset()
+	return a
+}
+
+func (a *PercentileAgg) NewStringAgg() execute.DoStringAgg {
+	return nil
+}
+
+func (a *PercentileAgg) DoFloat(vs []float64) {
+	for _, v := range vs {
+		a.digest.Add(v, 1)
+	}
+}
+
+func (a *PercentileAgg) Type() execute.DataType {
+	return execute.TFloat
+}
+func (a *PercentileAgg) ValueFloat() float64 {
+	return a.digest.Quantile(a.Quantile)
+}
+
+type ExactPercentileAgg struct {
+	Quantile float64
+
+	data []float64
+}
+
+func createExactPercentileTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	ps, ok := spec.(*ExactPercentileProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+	}
+	agg := &ExactPercentileAgg{
+		Quantile: ps.Percentile,
+	}
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), agg, a.Allocator())
+	return t, d, nil
+}
+
+func (a *ExactPercentileAgg) reset() {
+	a.data = a.data[0:0]
+}
+func (a *ExactPercentileAgg) NewBoolAgg() execute.DoBoolAgg {
+	return nil
+}
+
+func (a *ExactPercentileAgg) NewIntAgg() execute.DoIntAgg {
+	return nil
+}
+
+func (a *ExactPercentileAgg) NewUIntAgg() execute.DoUIntAgg {
+	return nil
+}
+
+func (a *ExactPercentileAgg) NewFloatAgg() execute.DoFloatAgg {
+	a.reset()
+	return a
+}
+
+func (a *ExactPercentileAgg) NewStringAgg() execute.DoStringAgg {
+	return nil
+}
+
+func (a *ExactPercentileAgg) DoFloat(vs []float64) {
+	a.data = append(a.data, vs...)
+}
+
+func (a *ExactPercentileAgg) Type() execute.DataType {
+	return execute.TFloat
+}
+
+func (a *ExactPercentileAgg) ValueFloat() float64 {
+	sort.Float64s(a.data)
+
+	x := a.Quantile * float64(len(a.data)-1)
+	x0 := math.Floor(x)
+	x1 := math.Ceil(x)
+
+	if x0 == x1 {
+		return a.data[int(x0)]
+	}
+
+	// Linear interpolate
+	y0 := a.data[int(x0)]
+	y1 := a.data[int(x1)]
+	y := y0*(x1-x) + y1*(x-x0)
+
+	return y
+}

--- a/functions/percentile_test.go
+++ b/functions/percentile_test.go
@@ -1,0 +1,150 @@
+package functions_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/influxdata/ifql/functions"
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/query/execute/executetest"
+	"github.com/influxdata/ifql/query/querytest"
+)
+
+func TestPercentileOperation_Marshaling(t *testing.T) {
+	data := []byte(`{"id":"percentile","kind":"percentile","spec":{"percentile":0.9}}`)
+	op := &query.Operation{
+		ID: "percentile",
+		Spec: &functions.PercentileOpSpec{
+			Percentile: 0.9,
+		},
+	}
+
+	querytest.OperationMarshalingTestHelper(t, data, op)
+}
+
+func TestPercentile_Process(t *testing.T) {
+	testCases := []struct {
+		name       string
+		data       []float64
+		percentile float64
+		exact      bool
+		want       float64
+	}{
+		{
+			name:       "zero",
+			data:       []float64{0, 0, 0},
+			percentile: 0.5,
+			want:       0.0,
+		},
+		{
+			name:       "50th",
+			data:       []float64{1, 2, 3, 4, 5, 5, 4, 3, 2, 1},
+			percentile: 0.5,
+			want:       3,
+		},
+		{
+			name:       "75th",
+			data:       []float64{1, 2, 3, 4, 5, 5, 4, 3, 2, 1},
+			percentile: 0.75,
+			want:       4,
+		},
+		{
+			name:       "90th",
+			data:       []float64{1, 2, 3, 4, 5, 5, 4, 3, 2, 1},
+			percentile: 0.9,
+			want:       5,
+		},
+		{
+			name:       "99th",
+			data:       []float64{1, 2, 3, 4, 5, 5, 4, 3, 2, 1},
+			percentile: 0.99,
+			want:       5,
+		},
+		{
+			name:       "exact 50th",
+			data:       []float64{1, 2, 3, 4, 5},
+			percentile: 0.5,
+			exact:      true,
+			want:       3,
+		},
+		{
+			name:       "exact 75th",
+			data:       []float64{1, 2, 3, 4, 5},
+			percentile: 0.75,
+			exact:      true,
+			want:       4,
+		},
+		{
+			name:       "exact 90th",
+			data:       []float64{1, 2, 3, 4, 5},
+			percentile: 0.9,
+			exact:      true,
+			want:       4.6,
+		},
+		{
+			name:       "exact 99th",
+			data:       []float64{1, 2, 3, 4, 5},
+			percentile: 0.99,
+			exact:      true,
+			want:       4.96,
+		},
+		{
+			name:       "exact 100th",
+			data:       []float64{1, 2, 3, 4, 5},
+			percentile: 1,
+			exact:      true,
+			want:       5,
+		},
+		{
+			name:       "exact 50th normal",
+			data:       NormalData,
+			percentile: 0.5,
+			exact:      true,
+			want:       9.997645059676595,
+		},
+		{
+			name:       "normal",
+			data:       NormalData,
+			percentile: 0.9,
+			want:       13.843815760607427,
+		},
+		{
+			name: "NaN",
+			data: []float64{},
+			want: math.NaN(),
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var agg execute.Aggregate
+			if tc.exact {
+				agg = &functions.ExactPercentileAgg{Quantile: tc.percentile}
+			} else {
+				agg = &functions.PercentileAgg{
+					Quantile:    tc.percentile,
+					Compression: 1000,
+				}
+			}
+			executetest.AggFuncTestHelper(
+				t,
+				agg,
+				tc.data,
+				tc.want,
+			)
+		})
+	}
+}
+
+func BenchmarkPercentile(b *testing.B) {
+	executetest.AggFuncBenchmarkHelper(
+		b,
+		&functions.PercentileAgg{
+			Quantile:    0.9,
+			Compression: 1000,
+		},
+		NormalData,
+		13.843815760607427,
+	)
+}

--- a/functions/spread_test.go
+++ b/functions/spread_test.go
@@ -36,6 +36,6 @@ func BenchmarkSpread(b *testing.B) {
 		b,
 		new(functions.SpreadAgg),
 		NormalData,
-		28.227196,
+		28.227196461851847,
 	)
 }


### PR DESCRIPTION
This PR adds the percentile and median functions.

Both can be made to be exact by passing the `exact: true` argument, otherwise the functions approximate the percentile by using the t-digest method.


Usage:

```
data = from(db:"telegraf")
    |> range(start:-1m)
    |> filter(fn: (r) => r._measurement == "cpu" and r._field == "usage_idle" and r.cpu == "cpu-total")

data
    |> percentile(p:0.9)
    |> yield(name:"approx 90th")


data
    |> percentile(p:0.9, exact:true)
    |> yield(name:"exact 90th")

```

