### PR TITLE
Add support for pushing down group by with aggregates

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -1690,4 +1690,15 @@ var binaryFuncs = map[binarySignature]struct {
 		},
 		ResultKind: semantic.Bool,
 	},
+	{Operator: ast.NotEqualOperator, Left: semantic.String, Right: semantic.String}: {
+		Func: func(scope Scope, left, right Evaluator) Value {
+			l := left.EvalString(scope)
+			r := right.EvalString(scope)
+			return value{
+				typ:   semantic.Bool,
+				Value: l != r,
+			}
+		},
+		ResultKind: semantic.Bool,
+	},
 }

--- a/functions/count.go
+++ b/functions/count.go
@@ -50,6 +50,13 @@ func (s *CountProcedureSpec) Copy() plan.ProcedureSpec {
 	return new(CountProcedureSpec)
 }
 
+func (s *CountProcedureSpec) AggregateMethod() string {
+	return CountKind
+}
+func (s *CountProcedureSpec) ReAggregateSpec() plan.ProcedureSpec {
+	return new(SumProcedureSpec)
+}
+
 func (s *CountProcedureSpec) PushDownRules() []plan.PushDownRule {
 	return []plan.PushDownRule{{
 		Root:    FromKind,
@@ -67,11 +74,11 @@ func (s *CountProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Pro
 		root = dup()
 		selectSpec = root.Spec.(*FromProcedureSpec)
 		selectSpec.AggregateSet = false
-		selectSpec.AggregateType = ""
+		selectSpec.AggregateMethod = ""
 		return
 	}
 	selectSpec.AggregateSet = true
-	selectSpec.AggregateType = CountKind
+	selectSpec.AggregateMethod = s.AggregateMethod()
 }
 
 type CountAgg struct {

--- a/functions/count_test.go
+++ b/functions/count_test.go
@@ -106,8 +106,8 @@ func TestCount_PushDown(t *testing.T) {
 	}
 	want := &plan.Procedure{
 		Spec: &functions.FromProcedureSpec{
-			AggregateSet:  true,
-			AggregateType: functions.CountKind,
+			AggregateSet:    true,
+			AggregateMethod: functions.CountKind,
 		},
 	}
 
@@ -118,8 +118,8 @@ func TestCount_PushDown_Duplicate(t *testing.T) {
 	spec := new(functions.CountProcedureSpec)
 	root := &plan.Procedure{
 		Spec: &functions.FromProcedureSpec{
-			AggregateSet:  true,
-			AggregateType: functions.CountKind,
+			AggregateSet:    true,
+			AggregateMethod: functions.CountKind,
 		},
 	}
 	want := &plan.Procedure{

--- a/functions/from.go
+++ b/functions/from.go
@@ -83,8 +83,8 @@ type FromProcedureSpec struct {
 	GroupExcept []string
 	GroupKeep   []string
 
-	AggregateSet  bool
-	AggregateType string
+	AggregateSet    bool
+	AggregateMethod string
 }
 
 func newFromProcedure(qs query.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
@@ -134,7 +134,7 @@ func (s *FromProcedureSpec) Copy() plan.ProcedureSpec {
 	ns.Window = s.Window
 
 	ns.AggregateSet = s.AggregateSet
-	ns.AggregateType = s.AggregateType
+	ns.AggregateMethod = s.AggregateMethod
 
 	return ns
 }
@@ -166,19 +166,19 @@ func createFromSource(prSpec plan.ProcedureSpec, id execute.DatasetID, sr execut
 		id,
 		sr,
 		execute.ReadSpec{
-			Database:      spec.Database,
-			Hosts:         spec.Hosts,
-			Predicate:     spec.Filter,
-			PointsLimit:   spec.PointsLimit,
-			SeriesLimit:   spec.SeriesLimit,
-			SeriesOffset:  spec.SeriesOffset,
-			Descending:    spec.Descending,
-			OrderByTime:   spec.OrderByTime,
-			MergeAll:      spec.MergeAll,
-			GroupKeys:     spec.GroupKeys,
-			GroupExcept:   spec.GroupExcept,
-			GroupKeep:     spec.GroupKeep,
-			AggregateType: spec.AggregateType,
+			Database:        spec.Database,
+			Hosts:           spec.Hosts,
+			Predicate:       spec.Filter,
+			PointsLimit:     spec.PointsLimit,
+			SeriesLimit:     spec.SeriesLimit,
+			SeriesOffset:    spec.SeriesOffset,
+			Descending:      spec.Descending,
+			OrderByTime:     spec.OrderByTime,
+			MergeAll:        spec.MergeAll,
+			GroupKeys:       spec.GroupKeys,
+			GroupExcept:     spec.GroupExcept,
+			GroupKeep:       spec.GroupKeep,
+			AggregateMethod: spec.AggregateMethod,
 		},
 		bounds,
 		w,

--- a/functions/sum.go
+++ b/functions/sum.go
@@ -51,6 +51,13 @@ func (s *SumProcedureSpec) Copy() plan.ProcedureSpec {
 	return new(SumProcedureSpec)
 }
 
+func (s *SumProcedureSpec) AggregateMethod() string {
+	return SumKind
+}
+func (s *SumProcedureSpec) ReAggregateSpec() plan.ProcedureSpec {
+	return new(SumProcedureSpec)
+}
+
 func (s *SumProcedureSpec) PushDownRules() []plan.PushDownRule {
 	return []plan.PushDownRule{{
 		Root:    FromKind,
@@ -67,11 +74,11 @@ func (s *SumProcedureSpec) PushDown(root *plan.Procedure, dup func() *plan.Proce
 		root = dup()
 		selectSpec = root.Spec.(*FromProcedureSpec)
 		selectSpec.AggregateSet = false
-		selectSpec.AggregateType = ""
+		selectSpec.AggregateMethod = ""
 		return
 	}
 	selectSpec.AggregateSet = true
-	selectSpec.AggregateType = SumKind
+	selectSpec.AggregateMethod = s.AggregateMethod()
 }
 
 type SumAgg struct{}

--- a/functions/sum_test.go
+++ b/functions/sum_test.go
@@ -58,8 +58,8 @@ func TestSum_PushDown(t *testing.T) {
 	}
 	want := &plan.Procedure{
 		Spec: &functions.FromProcedureSpec{
-			AggregateSet:  true,
-			AggregateType: functions.SumKind,
+			AggregateSet:    true,
+			AggregateMethod: functions.SumKind,
 		},
 	}
 
@@ -69,8 +69,8 @@ func TestSum_PushDown_Duplicate(t *testing.T) {
 	spec := new(functions.SumProcedureSpec)
 	root := &plan.Procedure{
 		Spec: &functions.FromProcedureSpec{
-			AggregateSet:  true,
-			AggregateType: functions.SumKind,
+			AggregateSet:    true,
+			AggregateMethod: functions.SumKind,
 		},
 	}
 	want := &plan.Procedure{

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1366,4 +1366,9 @@ var binaryFuncLookup = map[binaryFuncSignature]binaryFunc{
 		r := rv.Value().(float64)
 		return NewBoolValue(l != r)
 	},
+	{operator: ast.NotEqualOperator, left: semantic.String, right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Value().(string)
+		r := rv.Value().(string)
+		return NewBoolValue(l != r)
+	},
 }

--- a/query/execute/row_fn.go
+++ b/query/execute/row_fn.go
@@ -370,7 +370,7 @@ func toComparisonOperator(o ast.OperatorKind) (storage.Node_Comparison, error) {
 	switch o {
 	case ast.EqualOperator:
 		return storage.ComparisonEqual, nil
-	case ast.NotOperator:
+	case ast.NotEqualOperator:
 		return storage.ComparisonNotEqual, nil
 	case ast.StartsWithOperator:
 		return storage.ComparisonStartsWith, nil

--- a/query/execute/storage.go
+++ b/query/execute/storage.go
@@ -28,7 +28,7 @@ type ReadSpec struct {
 	SeriesOffset int64
 	Descending   bool
 
-	AggregateType string
+	AggregateMethod string
 
 	// OrderByTime indicates that series reads should produce all
 	// series for a time before producing any series for a larger time.
@@ -130,7 +130,7 @@ func (bi *storageBlockIterator) Do(f func(Block) error) error {
 	req.SeriesOffset = uint64(bi.readSpec.SeriesOffset)
 	req.Trace = bi.trace
 
-	if agg, err := determineAggregateType(bi.readSpec.AggregateType); err != nil {
+	if agg, err := determineAggregateMethod(bi.readSpec.AggregateMethod); err != nil {
 		return err
 	} else if agg != storage.AggregateTypeNone {
 		req.Aggregate = &storage.Aggregate{Type: agg}
@@ -186,7 +186,7 @@ func (bi *storageBlockIterator) Do(f func(Block) error) error {
 	return nil
 }
 
-func determineAggregateType(agg string) (storage.Aggregate_AggregateType, error) {
+func determineAggregateMethod(agg string) (storage.Aggregate_AggregateType, error) {
 	if agg == "" {
 		return storage.AggregateTypeNone, nil
 	}

--- a/query/plan/logical.go
+++ b/query/plan/logical.go
@@ -55,6 +55,9 @@ func (p *logicalPlanner) Plan(q *query.Spec) (*LogicalPlanSpec, error) {
 func ProcedureIDFromOperationID(id query.OperationID) ProcedureID {
 	return ProcedureID(uuid.NewV5(RootUUID, string(id)))
 }
+func ProcedureIDFromParentID(id ProcedureID) ProcedureID {
+	return ProcedureID(uuid.NewV5(RootUUID, id.String()))
+}
 
 func (p *logicalPlanner) walkQuery(o *query.Operation) error {
 	spec, err := p.createSpec(o.Spec.Kind(), o.Spec)

--- a/query/plan/logical_test.go
+++ b/query/plan/logical_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/ifql/functions"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/plan"
+	"github.com/influxdata/ifql/query/plan/plantest"
 )
 
 func TestLogicalPlanner_Plan(t *testing.T) {
@@ -175,8 +176,8 @@ func TestLogicalPlanner_Plan(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !cmp.Equal(got, tc.ap) {
-				t.Errorf("unexpected logical plan -want/+got %s", cmp.Diff(tc.ap, got))
+			if !cmp.Equal(got, tc.ap, plantest.CmpOptions...) {
+				t.Errorf("unexpected logical plan -want/+got %s", cmp.Diff(tc.ap, got, plantest.CmpOptions...))
 			}
 		})
 	}

--- a/query/plan/plantest/physical.go
+++ b/query/plan/plantest/physical.go
@@ -9,6 +9,10 @@ import (
 	"github.com/influxdata/ifql/semantic/semantictest"
 )
 
+var CmpOptions = []cmp.Option{
+	cmpopts.IgnoreUnexported(plan.Procedure{}),
+}
+
 func PhysicalPlan_PushDown_Match_TestHelper(t *testing.T, spec plan.PushDownProcedureSpec, matchSpec plan.ProcedureSpec, want []bool) {
 	t.Helper()
 
@@ -45,7 +49,8 @@ func PhysicalPlan_PushDown_TestHelper(t *testing.T, spec plan.PushDownProcedureS
 		}
 	}
 
-	opts := append(semantictest.CmpOptions, cmpopts.EquateEmpty())
+	opts := append(CmpOptions, cmpopts.EquateEmpty())
+	opts = append(opts, semantictest.CmpOptions...)
 	if !cmp.Equal(got, want, opts...) {
 		t.Errorf("unexpected PushDown: -want/+got:\n%s", cmp.Diff(want, got, opts...))
 	}

--- a/query/plan/rules.go
+++ b/query/plan/rules.go
@@ -1,0 +1,12 @@
+package plan
+
+type RewriteRule interface {
+	Root() ProcedureKind
+	Rewrite(*Procedure, PlanRewriter) error
+}
+
+var rewriteRules []RewriteRule
+
+func RegisterRewriteRule(r RewriteRule) {
+	rewriteRules = append(rewriteRules, r)
+}

--- a/semantic/binary_types.go
+++ b/semantic/binary_types.go
@@ -91,13 +91,14 @@ var binaryTypesLookup = map[binarySignature]Kind{
 
 	// NotEqualOperator
 
-	{operator: ast.NotEqualOperator, left: Int, right: Int}:     Bool,
-	{operator: ast.NotEqualOperator, left: Int, right: UInt}:    Bool,
-	{operator: ast.NotEqualOperator, left: Int, right: Float}:   Bool,
-	{operator: ast.NotEqualOperator, left: UInt, right: Int}:    Bool,
-	{operator: ast.NotEqualOperator, left: UInt, right: UInt}:   Bool,
-	{operator: ast.NotEqualOperator, left: UInt, right: Float}:  Bool,
-	{operator: ast.NotEqualOperator, left: Float, right: Int}:   Bool,
-	{operator: ast.NotEqualOperator, left: Float, right: UInt}:  Bool,
-	{operator: ast.NotEqualOperator, left: Float, right: Float}: Bool,
+	{operator: ast.NotEqualOperator, left: Int, right: Int}:       Bool,
+	{operator: ast.NotEqualOperator, left: Int, right: UInt}:      Bool,
+	{operator: ast.NotEqualOperator, left: Int, right: Float}:     Bool,
+	{operator: ast.NotEqualOperator, left: UInt, right: Int}:      Bool,
+	{operator: ast.NotEqualOperator, left: UInt, right: UInt}:     Bool,
+	{operator: ast.NotEqualOperator, left: UInt, right: Float}:    Bool,
+	{operator: ast.NotEqualOperator, left: Float, right: Int}:     Bool,
+	{operator: ast.NotEqualOperator, left: Float, right: UInt}:    Bool,
+	{operator: ast.NotEqualOperator, left: Float, right: Float}:   Bool,
+	{operator: ast.NotEqualOperator, left: String, right: String}: Bool,
 }


### PR DESCRIPTION
Now the planner has the concept of rewrite rules. A new rewrite rule has been added which rewrites GroupBy + Aggregate operations as a map/reduce with two aggregates, one at the storage layer and one at the query layer.

The first aggregate is pushed down to the storage layer and is applied to each series individually. The secondary aggregate is applied within the IFQL query engine to aggregate the series per group into a single record.

Currently only Count and Sum support this behavior. 

Count pushes down a count aggregate and uses a sum as the reaggregate.
Sum pushes down a sum aggregate and uses a sum as the reaggregate.

