### PR TITLE
Add a REPL for IFQL

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,6 +23,12 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  name = "github.com/c-bata/go-prompt"
+  packages = ["."]
+  revision = "c292a2f4b4fe8563883871456e19028ff9df0f26"
+  version = "v0.1.1"
+
+[[projects]]
   branch = "master"
   name = "github.com/codahale/hdrhistogram"
   packages = ["."]
@@ -221,7 +227,7 @@
     "status",
     "yarpcproto"
   ]
-  revision = "036268cdec22b7074cd6d50cc6d7315c667063c7"
+  revision = "f0da2db138cad2fb425541938fc28dd5a5bc6918"
 
 [[projects]]
   name = "github.com/jessevdk/go-flags"
@@ -281,6 +287,12 @@
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/pkg/term"
+  packages = ["termios"]
+  revision = "b1f72af2d63057363398bec5873d16a98b453312"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
@@ -382,7 +394,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
+  revision = "2c42eef0765b9837fbdab12011af7830f55f88f0"
 
 [[projects]]
   branch = "master"
@@ -416,6 +428,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a7deb7039500ef615c52906accd19280fc42008713bc6e3a92793e7f3e7e8569"
+  inputs-digest = "b020a89be355de84a5ca3ba9a63e4ec9c0fd9a57d7b4b4159d110980b4189e24"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/functions/join.go
+++ b/functions/join.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/influxdata/ifql/compiler"
-	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -77,9 +76,12 @@ func createJoinOpSpec(args query.Arguments, a *query.Administration) (query.Oper
 			if t.Type().Kind() != semantic.Object {
 				return nil, fmt.Errorf("value for key %q in tables must be an object: got %v", k, t.Type().Kind())
 			}
-			id := query.GetIDFromObject(t.(interpreter.Object))
-			a.AddParent(id)
-			spec.TableNames[id] = k
+			if t.Type() != query.TableObjectType {
+				return nil, fmt.Errorf("value for key %q in tables must be an table object: got %v", k, t.Type())
+			}
+			p := t.(query.TableObject)
+			a.AddParent(p)
+			spec.TableNames[p.ID()] = k
 		}
 	}
 

--- a/functions/yield.go
+++ b/functions/yield.go
@@ -36,11 +36,14 @@ func createYieldOpSpec(args query.Arguments, a *query.Administration) (query.Ope
 
 	spec := new(YieldOpSpec)
 
-	name, err := args.GetRequiredString("name")
+	name, ok, err := args.GetString("name")
 	if err != nil {
 		return nil, err
+	} else if ok {
+		spec.Name = name
+	} else {
+		spec.Name = "_result"
 	}
-	spec.Name = name
 
 	return spec, nil
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -137,6 +137,16 @@ func TestEval(t *testing.T) {
 			`,
 		},
 		{
+			name: "scope closing mutable",
+			query: `
+			x = 5
+            plusX = (r) => r + x
+            plusX(r:2) == 7 or fail()
+			x = 1
+            plusX(r:2) == 3 or fail()
+			`,
+		},
+		{
 			name: "return map from func",
 			query: `
             toMap = (a,b) => ({

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -112,6 +112,9 @@ func (c *Controller) compileQuery(q *Query, queryStr string) error {
 }
 
 func (c *Controller) enqueueQuery(q *Query) error {
+	if c.verbose {
+		log.Println("query", query.Formatted(&q.Spec, query.FmtJSON))
+	}
 	q.queue()
 	if err := q.Spec.Validate(); err != nil {
 		return errors.Wrap(err, "invalid query")

--- a/query/execute/format.go
+++ b/query/execute/format.go
@@ -18,7 +18,7 @@ type Formatter struct {
 	// fmtBuf is used to format values
 	fmtBuf [64]byte
 
-	opts *FormatOptions
+	opts FormatOptions
 
 	cols orderedCols
 }
@@ -29,9 +29,7 @@ type FormatOptions struct {
 }
 
 func DefaultFormatOptions() *FormatOptions {
-	return &FormatOptions{
-		RepeatHeaderCount: 0,
-	}
+	return &FormatOptions{}
 }
 
 var eol = []byte{'\n'}
@@ -44,7 +42,7 @@ func NewFormatter(b Block, opts *FormatOptions) *Formatter {
 	}
 	return &Formatter{
 		b:    b,
-		opts: opts,
+		opts: *opts,
 	}
 }
 

--- a/query/plan/physical.go
+++ b/query/plan/physical.go
@@ -167,7 +167,7 @@ func (p *planner) Plan(lp *LogicalPlanSpec, s Storage, now time.Time) (*PlanSpec
 	}
 
 	if p.plan.Bounds.Start.IsZero() && p.plan.Bounds.Stop.IsZero() {
-		return nil, errors.New("unbounded queries are not supported. Add a '.range' call to bound the query.")
+		return nil, errors.New("unbounded queries are not supported. Add a 'range' call to bound the query.")
 	}
 
 	// Update concurrency quota

--- a/query/query.go
+++ b/query/query.go
@@ -72,6 +72,8 @@ func (q *Spec) Parents(id OperationID) []*Operation {
 // prepare populates the internal datastructure needed to quickly navigate the query DAG.
 // As a result the query DAG is validated.
 func (q *Spec) prepare() error {
+	q.sorted = q.sorted[0:0]
+
 	parents, children, roots, err := q.determineParentsChildrenAndRoots()
 	if err != nil {
 		return err

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1,0 +1,204 @@
+package repl
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+
+	prompt "github.com/c-bata/go-prompt"
+	"github.com/influxdata/ifql/functions"
+	"github.com/influxdata/ifql/interpreter"
+	"github.com/influxdata/ifql/parser"
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/control"
+	"github.com/influxdata/ifql/query/execute"
+	"github.com/influxdata/ifql/semantic"
+	"github.com/pkg/errors"
+)
+
+type REPL struct {
+	scope        *interpreter.Scope
+	declarations semantic.DeclarationScope
+	c            *control.Controller
+	d            query.Domain
+
+	cancelMu   sync.Mutex
+	cancelFunc context.CancelFunc
+}
+
+func addBuiltIn(script string, d query.Domain, scope *interpreter.Scope, declarations semantic.DeclarationScope) error {
+	astProg, err := parser.NewAST(script)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse builtin")
+	}
+	semProg, err := semantic.New(astProg, declarations)
+	if err != nil {
+		return errors.Wrap(err, "failed to create semantic graph for builtin")
+	}
+
+	if err := interpreter.Eval(semProg, scope, d); err != nil {
+		return errors.Wrap(err, "failed to evaluate builtin")
+	}
+	return nil
+}
+
+func New(c *control.Controller) *REPL {
+	scope, declarations := query.BuiltIns()
+	d := query.NewDomain()
+	addBuiltIn("run = () => yield(table:_)", d, scope, declarations)
+	return &REPL{
+		scope:        scope,
+		declarations: declarations,
+		c:            c,
+		d:            d,
+	}
+}
+
+func (r *REPL) Run() {
+	p := prompt.New(
+		r.input,
+		r.completer,
+		prompt.OptionPrefix("> "),
+		prompt.OptionTitle("ifql"),
+	)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT)
+	go func() {
+		for range sigs {
+			r.cancel()
+		}
+	}()
+	p.Run()
+}
+
+func (r *REPL) cancel() {
+	r.cancelMu.Lock()
+	defer r.cancelMu.Unlock()
+	if r.cancelFunc != nil {
+		r.cancelFunc()
+		r.cancelFunc = nil
+	}
+}
+
+func (r *REPL) setCancel(cf context.CancelFunc) {
+	r.cancelMu.Lock()
+	defer r.cancelMu.Unlock()
+	r.cancelFunc = cf
+}
+func (r *REPL) clearCancel() {
+	r.setCancel(nil)
+}
+
+func (r *REPL) completer(d prompt.Document) []prompt.Suggest {
+	names := r.scope.Names()
+	sort.Strings(names)
+
+	s := make([]prompt.Suggest, 0, len(names))
+	for _, n := range names {
+		if n == "_" || !strings.HasPrefix(n, "_") {
+			s = append(s, prompt.Suggest{Text: n})
+		}
+	}
+	return prompt.FilterHasPrefix(s, d.GetWordBeforeCursor(), true)
+}
+
+func (r *REPL) Input(t string) error {
+	_, err := r.executeLine(t, false)
+	return err
+}
+
+// input processes a line of input and prints the result.
+func (r *REPL) input(t string) {
+	v, err := r.executeLine(t, true)
+	if err != nil {
+		fmt.Println("Error:", err)
+	} else if v != nil {
+		fmt.Println(v)
+	}
+}
+
+// executeLine processes a line of input.
+// If the input evaluates to a valid value, that value is returned.
+func (r *REPL) executeLine(t string, expectYield bool) (interpreter.Value, error) {
+	if t == "" {
+		return nil, nil
+	}
+	astProg, err := parser.NewAST(t)
+	if err != nil {
+		return nil, err
+	}
+
+	semProg, err := semantic.New(astProg, r.declarations)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := interpreter.Eval(semProg, r.scope, r.d); err != nil {
+		return nil, err
+	}
+
+	v := r.scope.Return()
+
+	// Check for yield and execute query
+	if v.Type() == query.TableObjectType {
+		t := v.(query.TableObject)
+		if !expectYield || (expectYield && t.Kind() == functions.YieldKind) {
+			spec := t.ToSpec()
+			// Do query
+			return nil, r.doQuery(spec)
+		}
+	}
+
+	r.scope.Set("_", v)
+
+	// Print value
+	if v.Type() != semantic.Invalid {
+		return v, nil
+	}
+	return nil, nil
+}
+
+func (r *REPL) doQuery(spec *query.Spec) error {
+	// Setup cancel context
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	r.setCancel(cancelFunc)
+	defer cancelFunc()
+	defer r.clearCancel()
+
+	q, err := r.c.Query(ctx, spec)
+	if err != nil {
+		return err
+	}
+	defer q.Done()
+
+	results, ok := <-q.Ready
+	if !ok {
+		err := q.Err()
+		return err
+	}
+
+	names := make([]string, 0, len(results))
+	for name := range results {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		r := results[name]
+		blocks := r.Blocks()
+		fmt.Println("Result:", name)
+		err := blocks.Do(func(b execute.Block) error {
+			execute.NewFormatter(b, nil).WriteTo(os.Stdout)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/semantic/types.go
+++ b/semantic/types.go
@@ -260,6 +260,8 @@ func objectTypeOf(e *ObjectExpression) Type {
 	return NewObjectType(propertyTypes)
 }
 
+var EmptyObject = NewObjectType(nil)
+
 func NewObjectType(propertyTypes map[string]Type) Type {
 	propertyNames := make([]string, 0, len(propertyTypes))
 	for name := range propertyTypes {


### PR DESCRIPTION
The REPL for IFQL allows for execution of IFQL code.

The REPL relies on the user to explicitly `yield` the query in order to know when to execute the query. This prevents executing a query before all functions have been applied. In the future it will be possible to partially execute a query allowing for interactive intermediate results.

Expressions that are evaluated are stored in the variable `_`. This allows for writing multiline queries by chaining calls using `_ |>` to pass the previous result into the current line.

Here is an example usage of the IFQL REPL. https://asciinema.org/a/yBUXyYT7AdUAmVI86Jjg4kLg1

There is lots of room for improvement here, but for now this should provide a usable REPL. 

