### PR TITLE
Add useStartTime to all aggregate/selector functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,21 @@ Example: `from(db:"telegraf")`
 
 Counts the number of results
 
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
+
 Example: `from(db:"telegraf") |> count()`
 
 #### first
 
 Returns the first result of the query
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db:"telegraf") |> first()`
 
@@ -187,7 +197,13 @@ The parameter is a map, which uses the same keys found in the `tables` map.
 The function is called for each joined set of records from the tables.
 
 #### last
+
 Returns the last result of the query
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db: "telegraf") |> last()`
 
@@ -232,6 +248,11 @@ from(db:"foo")
 
 Returns the max value within the results
 
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
+
 Example:
 ```
 from(db:"foo")
@@ -244,7 +265,13 @@ from(db:"foo")
 ```
 
 #### mean
+
 Returns the mean of the values within the results
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example:
 ```
@@ -257,7 +284,13 @@ from(db:"foo")
 ```
 
 #### min
+
 Returns the min value within the results
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example:
 ```
@@ -291,6 +324,20 @@ Defaults to "now"
 
 #### sample
 
+Sample values from a table.
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
+* `n`
+Sample every Nth element
+* `pos`
+Position offset from start of results to begin sampling
+`pos` must be less than `n`
+If `pos` less than 0, a random offset is used.
+Default is -1 (random offset)
+
 Example to sample every fifth point starting from the second element:
 ```
 from(db:"foo")
@@ -300,15 +347,6 @@ from(db:"foo")
     |> sample(n: 5, pos: 1)
 ```
 
-##### options
-* `n`
-Sample every Nth element
-* `pos`
-Position offset from start of results to begin sampling
-`pos` must be less than `n`
-If `pos` less than 0, a random offset is used.
-Default is -1 (random offset)
-
 #### set
 Add tag of key and value to set
 Example: `from(db: "telegraf") |> set(key: "mykey", value: "myvalue")`
@@ -317,7 +355,13 @@ Example: `from(db: "telegraf") |> set(key: "mykey", value: "myvalue")`
 * `value` string
 
 #### skew
+
 Skew of the results
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db: "telegraf") |> range(start: -30m, stop: -15m) |> skew()`
 
@@ -354,17 +398,35 @@ from(db:"telegraf")
 Sort results descending
 
 #### spread
+
 Difference between min and max values
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db: "telegraf") |> range(start: -30m) |> spread()`
 
 #### stddev
+
 Standard Deviation of the results
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db: "telegraf") |> range(start: -30m, stop: -15m) |> stddev()`
 
 #### sum
+
 Sum of the results
+
+##### options
+
+*  `useStartTime` boolean
+Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db: "telegraf") |> range(start: -30m, stop: -15m) |> sum()`
 

--- a/functions/first_test.go
+++ b/functions/first_test.go
@@ -17,7 +17,9 @@ func TestFirstOperation_Marshaling(t *testing.T) {
 	op := &query.Operation{
 		ID: "first",
 		Spec: &functions.FirstOpSpec{
-			UseRowTime: true,
+			SelectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 		},
 	}
 

--- a/functions/last_test.go
+++ b/functions/last_test.go
@@ -17,7 +17,9 @@ func TestLastOperation_Marshaling(t *testing.T) {
 	op := &query.Operation{
 		ID: "last",
 		Spec: &functions.LastOpSpec{
-			UseRowTime: true,
+			SelectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 		},
 	}
 

--- a/functions/max_test.go
+++ b/functions/max_test.go
@@ -15,7 +15,9 @@ func TestMaxOperation_Marshaling(t *testing.T) {
 	op := &query.Operation{
 		ID: "max",
 		Spec: &functions.MaxOpSpec{
-			UseRowTime: true,
+			SelectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 		},
 	}
 

--- a/functions/min_test.go
+++ b/functions/min_test.go
@@ -15,7 +15,9 @@ func TestMinOperation_Marshaling(t *testing.T) {
 	op := &query.Operation{
 		ID: "min",
 		Spec: &functions.MinOpSpec{
-			UseRowTime: true,
+			SelectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 		},
 	}
 

--- a/functions/sample_test.go
+++ b/functions/sample_test.go
@@ -15,9 +15,11 @@ func TestSampleOperation_Marshaling(t *testing.T) {
 	op := &query.Operation{
 		ID: "sample",
 		Spec: &functions.SampleOpSpec{
-			UseRowTime: true,
-			N:          5,
-			Pos:        0,
+			SelectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
+			N:   5,
+			Pos: 0,
 		},
 	}
 

--- a/query/execute/aggergate_test.go
+++ b/query/execute/aggergate_test.go
@@ -18,6 +18,7 @@ func TestAggregate_Process(t *testing.T) {
 		name   string
 		bounds execute.Bounds
 		agg    execute.Aggregate
+		config execute.AggregateConfig
 		data   []*executetest.Block
 		want   func(b execute.Bounds) []*executetest.Block
 	}{
@@ -59,6 +60,51 @@ func TestAggregate_Process(t *testing.T) {
 					},
 					Data: [][]interface{}{
 						{execute.Time(100), 45.0},
+					},
+				}}
+			},
+		},
+		{
+			name: "single use start time",
+			config: execute.AggregateConfig{
+				UseStartTime: true,
+			},
+			bounds: execute.Bounds{
+				Start: 0,
+				Stop:  100,
+			},
+			agg: sumAgg,
+			data: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), 0.0},
+					{execute.Time(10), 1.0},
+					{execute.Time(20), 2.0},
+					{execute.Time(30), 3.0},
+					{execute.Time(40), 4.0},
+					{execute.Time(50), 5.0},
+					{execute.Time(60), 6.0},
+					{execute.Time(70), 7.0},
+					{execute.Time(80), 8.0},
+					{execute.Time(90), 9.0},
+				},
+			}},
+			want: func(b execute.Bounds) []*executetest.Block {
+				return []*executetest.Block{{
+					Bnds: b,
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), 45.0},
 					},
 				}}
 			},
@@ -356,7 +402,7 @@ func TestAggregate_Process(t *testing.T) {
 			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
-			agg := execute.NewAggregateTransformation(d, c, tc.bounds, tc.agg)
+			agg := execute.NewAggregateTransformation(d, c, tc.bounds, tc.agg, tc.config)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {

--- a/query/execute/selector_test.go
+++ b/query/execute/selector_test.go
@@ -14,12 +14,11 @@ import (
 func TestRowSelector_Process(t *testing.T) {
 	// All test cases use a simple MinSelector
 	testCases := []struct {
-		name       string
-		bounds     execute.Bounds
-		colLabel   string
-		useRowTime bool
-		data       []*executetest.Block
-		want       func(b execute.Bounds) []*executetest.Block
+		name           string
+		bounds         execute.Bounds
+		selectorConfig execute.SelectorConfig
+		data           []*executetest.Block
+		want           func(b execute.Bounds) []*executetest.Block
 	}{
 		{
 			name: "single",
@@ -63,8 +62,10 @@ func TestRowSelector_Process(t *testing.T) {
 			},
 		},
 		{
-			name:       "single useRowTime",
-			useRowTime: true,
+			name: "single useStartTime",
+			selectorConfig: execute.SelectorConfig{
+				UseStartTime: true,
+			},
 			bounds: execute.Bounds{
 				Start: 0,
 				Stop:  100,
@@ -105,8 +106,54 @@ func TestRowSelector_Process(t *testing.T) {
 			},
 		},
 		{
-			name:     "single custom column",
-			colLabel: "x",
+			name: "single useRowTime",
+			selectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
+			bounds: execute.Bounds{
+				Start: 0,
+				Stop:  100,
+			},
+			data: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), 0.0},
+					{execute.Time(10), 1.0},
+					{execute.Time(20), 2.0},
+					{execute.Time(30), 3.0},
+					{execute.Time(40), 4.0},
+					{execute.Time(50), 5.0},
+					{execute.Time(60), 6.0},
+					{execute.Time(70), 7.0},
+					{execute.Time(80), 8.0},
+					{execute.Time(90), 9.0},
+				},
+			}},
+			want: func(b execute.Bounds) []*executetest.Block {
+				return []*executetest.Block{{
+					Bnds: b,
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), 0.0},
+					},
+				}}
+			},
+		},
+		{
+			name: "single custom column",
+			selectorConfig: execute.SelectorConfig{
+				Column: "x",
+			},
 			bounds: execute.Bounds{
 				Start: 0,
 				Stop:  100,
@@ -213,8 +260,10 @@ func TestRowSelector_Process(t *testing.T) {
 			},
 		},
 		{
-			name:       "multiple blocks with tags and useRowTime",
-			useRowTime: true,
+			name: "multiple blocks with tags and useRowTime",
+			selectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 			bounds: execute.Bounds{
 				Start: 0,
 				Stop:  200,
@@ -356,7 +405,7 @@ func TestRowSelector_Process(t *testing.T) {
 			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
-			selector := execute.NewRowSelectorTransformation(d, c, tc.bounds, new(functions.MinSelector), tc.colLabel, tc.useRowTime)
+			selector := execute.NewRowSelectorTransformation(d, c, tc.bounds, new(functions.MinSelector), tc.selectorConfig)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {
@@ -381,11 +430,11 @@ func TestRowSelector_Process(t *testing.T) {
 func TestIndexSelector_Process(t *testing.T) {
 	// All test cases use a simple FirstSelector
 	testCases := []struct {
-		name       string
-		bounds     execute.Bounds
-		useRowTime bool
-		data       []*executetest.Block
-		want       func(b execute.Bounds) []*executetest.Block
+		name           string
+		bounds         execute.Bounds
+		selectorConfig execute.SelectorConfig
+		data           []*executetest.Block
+		want           func(b execute.Bounds) []*executetest.Block
 	}{
 		{
 			name: "single",
@@ -429,8 +478,54 @@ func TestIndexSelector_Process(t *testing.T) {
 			},
 		},
 		{
-			name:       "single useRowTime",
-			useRowTime: true,
+			name: "single useStartTime",
+			selectorConfig: execute.SelectorConfig{
+				UseStartTime: true,
+			},
+			bounds: execute.Bounds{
+				Start: 0,
+				Stop:  100,
+			},
+			data: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 0.0},
+					{execute.Time(10), 1.0},
+					{execute.Time(20), 2.0},
+					{execute.Time(30), 3.0},
+					{execute.Time(40), 4.0},
+					{execute.Time(50), 5.0},
+					{execute.Time(60), 6.0},
+					{execute.Time(70), 7.0},
+					{execute.Time(80), 8.0},
+					{execute.Time(90), 9.0},
+				},
+			}},
+			want: func(b execute.Bounds) []*executetest.Block {
+				return []*executetest.Block{{
+					Bnds: b,
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), 0.0},
+					},
+				}}
+			},
+		},
+		{
+			name: "single useRowTime",
+			selectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 			bounds: execute.Bounds{
 				Start: 0,
 				Stop:  100,
@@ -537,8 +632,10 @@ func TestIndexSelector_Process(t *testing.T) {
 			},
 		},
 		{
-			name:       "multiple blocks with tags and useRowTime",
-			useRowTime: true,
+			name: "multiple blocks with tags and useRowTime",
+			selectorConfig: execute.SelectorConfig{
+				UseRowTime: true,
+			},
 			bounds: execute.Bounds{
 				Start: 0,
 				Stop:  200,
@@ -680,7 +777,7 @@ func TestIndexSelector_Process(t *testing.T) {
 			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
-			selector := execute.NewIndexSelectorTransformation(d, c, tc.bounds, new(functions.FirstSelector), "_value", tc.useRowTime)
+			selector := execute.NewIndexSelectorTransformation(d, c, tc.bounds, new(functions.FirstSelector), tc.selectorConfig)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {


### PR DESCRIPTION
This PR adds the `useStartTime` argument to all selector and aggregate functions.

If `useStartTime`  is true, then the selectors use the start time of the data for the result of the selection/aggregation function. By default the stop time is used.