### PR TITLE
Add support for type casting functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db:"telegraf") |> count()`
 
+#### filter
+
+Filters the results using an expression
+
+Example:
+```
+from(db:"foo")
+    |> filter(fn: (r) => r["_measurement"]=="cpu" AND
+                r["_field"] == "usage_system" AND
+                r["service"] == "app-server")
+    |> range(start:-12h)
+    |> max()
+```
+
+##### options
+
+* `fn` function(record) bool
+
+Function to when filtering the records.
+The function must accept a single parameter which will be the records and return a boolean value.
+Records which evaluate to true, will be included in the results.
+
+
 #### first
 
 Returns the first result of the query
@@ -430,26 +453,69 @@ Use the start time as the timestamp of the resulting aggregate.
 
 Example: `from(db: "telegraf") |> range(start: -30m, stop: -15m) |> sum()`
 
-#### filter
-Filters the results using an expression
+### toBool
 
-Example:
-```
-from(db:"foo")
-    |> filter(fn: (r) => r["_measurement"]=="cpu" AND
-                r["_field"] == "usage_system" AND
-                r["service"] == "app-server")
-    |> range(start:-12h)
-    |> max()
-```
+Convert a value to a bool.
 
-##### options
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toBool()`
 
-* `fn` function(record) bool
+The function `toBool` is defined as `toBool = (table=<-) => table |> map(fn:(r) => bool(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `bool` function.
 
-Function to when filtering the records.
-The function must accept a single parameter which will be the records and return a boolean value.
-Records which evaluate to true, will be included in the results.
+### toInt
+
+Convert a value to a int.
+
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toInt()`
+
+The function `toInt` is defined as `toInt = (table=<-) => table |> map(fn:(r) => int(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `int` function.
+
+### toFloat
+
+Convert a value to a float.
+
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toFloat()`
+
+The function `toFloat` is defined as `toFloat = (table=<-) => table |> map(fn:(r) => float(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `float` function.
+
+### toDuration
+
+Convert a value to a duration.
+
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toDuration()`
+
+The function `toDuration` is defined as `toDuration = (table=<-) => table |> map(fn:(r) => duration(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `duration` function.
+
+### toString
+
+Convert a value to a string.
+
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toString()`
+
+The function `toString` is defined as `toString = (table=<-) => table |> map(fn:(r) => string(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `string` function.
+
+### toTime
+
+Convert a value to a time.
+
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toTime()`
+
+The function `toTime` is defined as `toTime = (table=<-) => table |> map(fn:(r) => time(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `time` function.
+
+### toUInt
+
+Convert a value to a uint.
+
+Example: `from(db: "telegraf") |> filter(fn:(r) => r._measurement == "mem" and r._field == "used") |> toUInt()`
+
+The function `toUInt` is defined as `toUInt = (table=<-) => table |> map(fn:(r) => uint(v:r._value))`.
+If you need to convert other columns use the `map` function directly with the `uint` function.
+
 
 #### window
 Partitions the results by a given time range

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/ifql/compiler"
 	"github.com/influxdata/ifql/semantic"
 	"github.com/influxdata/ifql/semantic/semantictest"
+	"github.com/influxdata/ifql/values"
 )
 
 var CmpOptions []cmp.Option
@@ -17,7 +18,7 @@ func init() {
 	CmpOptions = append(semantictest.CmpOptions, cmp.Comparer(ValueEqual))
 }
 
-func ValueEqual(x, y compiler.Value) bool {
+func ValueEqual(x, y values.Value) bool {
 	if x.Type() != y.Type() {
 		return false
 	}
@@ -56,8 +57,8 @@ func TestCompilationCache(t *testing.T) {
 	testCases := []struct {
 		name  string
 		types map[string]semantic.Type
-		scope map[string]compiler.Value
-		want  compiler.Value
+		scope map[string]values.Value
+		want  values.Value
 	}{
 		{
 			name: "floats",
@@ -65,11 +66,11 @@ func TestCompilationCache(t *testing.T) {
 				"a": semantic.Float,
 				"b": semantic.Float,
 			},
-			scope: map[string]compiler.Value{
-				"a": compiler.NewFloat(5),
-				"b": compiler.NewFloat(4),
+			scope: map[string]values.Value{
+				"a": values.NewFloatValue(5),
+				"b": values.NewFloatValue(4),
 			},
-			want: compiler.NewFloat(9),
+			want: values.NewFloatValue(9),
 		},
 		{
 			name: "ints",
@@ -77,11 +78,11 @@ func TestCompilationCache(t *testing.T) {
 				"a": semantic.Int,
 				"b": semantic.Int,
 			},
-			scope: map[string]compiler.Value{
-				"a": compiler.NewInt(5),
-				"b": compiler.NewInt(4),
+			scope: map[string]values.Value{
+				"a": values.NewIntValue(5),
+				"b": values.NewIntValue(4),
 			},
-			want: compiler.NewInt(9),
+			want: values.NewIntValue(9),
 		},
 		{
 			name: "uints",
@@ -89,16 +90,16 @@ func TestCompilationCache(t *testing.T) {
 				"a": semantic.UInt,
 				"b": semantic.UInt,
 			},
-			scope: map[string]compiler.Value{
-				"a": compiler.NewUInt(5),
-				"b": compiler.NewUInt(4),
+			scope: map[string]values.Value{
+				"a": values.NewUIntValue(5),
+				"b": values.NewUIntValue(4),
 			},
-			want: compiler.NewUInt(9),
+			want: values.NewUIntValue(9),
 		},
 	}
 
 	//Reuse the same cache for all test cases
-	cache := compiler.NewCompilationCache(add)
+	cache := compiler.NewCompilationCache(add, nil, nil)
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -134,13 +135,13 @@ func TestCompilationCache(t *testing.T) {
 	}
 }
 
-func TestCompile(t *testing.T) {
+func TestCompileAndEval(t *testing.T) {
 	testCases := []struct {
 		name    string
 		fn      *semantic.FunctionExpression
 		types   map[string]semantic.Type
-		scope   map[string]compiler.Value
-		want    compiler.Value
+		scope   map[string]values.Value
+		want    values.Value
 		wantErr bool
 	}{
 		{
@@ -154,10 +155,89 @@ func TestCompile(t *testing.T) {
 			types: map[string]semantic.Type{
 				"r": semantic.Int,
 			},
-			scope: map[string]compiler.Value{
-				"r": compiler.NewInt(4),
+			scope: map[string]values.Value{
+				"r": values.NewIntValue(4),
 			},
-			want:    compiler.NewInt(4),
+			want:    values.NewIntValue(4),
+			wantErr: false,
+		},
+		{
+			name: "call function",
+			fn: &semantic.FunctionExpression{
+				Params: []*semantic.FunctionParam{
+					{Key: &semantic.Identifier{Name: "r"}},
+				},
+				Body: &semantic.CallExpression{
+					Callee: &semantic.FunctionExpression{
+						Params: []*semantic.FunctionParam{
+							{Key: &semantic.Identifier{Name: "a"}, Default: &semantic.IntegerLiteral{Value: 1}},
+							{Key: &semantic.Identifier{Name: "b"}, Default: &semantic.IntegerLiteral{Value: 1}},
+						},
+						Body: &semantic.BinaryExpression{
+							Operator: ast.AdditionOperator,
+							Left:     &semantic.IdentifierExpression{Name: "a"},
+							Right:    &semantic.IdentifierExpression{Name: "b"},
+						},
+					},
+					Arguments: &semantic.ObjectExpression{
+						Properties: []*semantic.Property{
+							{Key: &semantic.Identifier{Name: "a"}, Value: &semantic.IntegerLiteral{Value: 1}},
+							{Key: &semantic.Identifier{Name: "b"}, Value: &semantic.IdentifierExpression{Name: "r"}},
+						},
+					},
+				},
+			},
+			types: map[string]semantic.Type{
+				"r": semantic.Int,
+			},
+			scope: map[string]values.Value{
+				"r": values.NewIntValue(4),
+			},
+			want:    values.NewIntValue(5),
+			wantErr: false,
+		},
+		{
+			name: "call function via identifier",
+			fn: &semantic.FunctionExpression{
+				Params: []*semantic.FunctionParam{
+					{Key: &semantic.Identifier{Name: "r"}},
+				},
+				Body: &semantic.BlockStatement{
+					Body: []semantic.Statement{
+						&semantic.NativeVariableDeclaration{
+							Identifier: &semantic.Identifier{Name: "f"}, Init: &semantic.FunctionExpression{
+								Params: []*semantic.FunctionParam{
+									{Key: &semantic.Identifier{Name: "a"}, Default: &semantic.IntegerLiteral{Value: 1}},
+									{Key: &semantic.Identifier{Name: "b"}, Default: &semantic.IntegerLiteral{Value: 1}},
+								},
+								Body: &semantic.BinaryExpression{
+									Operator: ast.AdditionOperator,
+									Left:     &semantic.IdentifierExpression{Name: "a"},
+									Right:    &semantic.IdentifierExpression{Name: "b"},
+								},
+							},
+						},
+						&semantic.ReturnStatement{
+							Argument: &semantic.CallExpression{
+								Callee: &semantic.IdentifierExpression{Name: "f"},
+								Arguments: &semantic.ObjectExpression{
+									Properties: []*semantic.Property{
+										{Key: &semantic.Identifier{Name: "a"}, Value: &semantic.IntegerLiteral{Value: 1}},
+										{Key: &semantic.Identifier{Name: "b"}, Value: &semantic.IdentifierExpression{Name: "r"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			types: map[string]semantic.Type{
+				"r": semantic.Int,
+			},
+			scope: map[string]values.Value{
+				"r": values.NewIntValue(4),
+			},
+			want:    values.NewIntValue(5),
 			wantErr: false,
 		},
 	}
@@ -165,9 +245,9 @@ func TestCompile(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			f, err := compiler.Compile(tc.fn, tc.types)
+			f, err := compiler.Compile(tc.fn, tc.types, nil, nil)
 			if tc.wantErr != (err != nil) {
-				t.Errorf("unexpected error %s", err)
+				t.Fatalf("unexpected error %s", err)
 			}
 
 			got, err := f.Eval(tc.scope)

--- a/complete/complete_test.go
+++ b/complete/complete_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/semantic"
+	"github.com/influxdata/ifql/values"
 )
 
 var scope *interpreter.Scope
@@ -15,12 +16,14 @@ var declarations semantic.DeclarationScope
 
 func init() {
 	query.FinalizeRegistration()
-	scope, declarations = query.BuiltIns()
+	s, d := query.BuiltIns()
+	scope = interpreter.NewScopeWithValues(s)
+	declarations = d
 }
 
 func TestNames(t *testing.T) {
 	s := interpreter.NewScope()
-	var v interpreter.Value
+	var v values.Value
 	s.Set("boom", v)
 	s.Set("tick", v)
 

--- a/functions/filter.go
+++ b/functions/filter.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/influxdata/ifql/ast"
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -38,13 +39,13 @@ func createFilterOpSpec(args query.Arguments, a *query.Administration) (query.Op
 		return nil, err
 	}
 
-	resolved, err := f.Resolve()
+	fn, err := interpreter.ResolveFunction(f)
 	if err != nil {
 		return nil, err
 	}
 
 	return &FilterOpSpec{
-		Fn: resolved,
+		Fn: fn,
 	}, nil
 }
 func newFilterOp() query.OperationSpec {

--- a/functions/from.go
+++ b/functions/from.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"fmt"
 
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -42,7 +43,10 @@ func createFromOpSpec(args query.Arguments, a *query.Administration) (query.Oper
 	if array, ok, err := args.GetArray("hosts", semantic.String); err != nil {
 		return nil, err
 	} else if ok {
-		spec.Hosts = array.AsStrings()
+		spec.Hosts, err = interpreter.ToStringArray(array)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return spec, nil
 }

--- a/functions/from_test.go
+++ b/functions/from_test.go
@@ -17,7 +17,7 @@ func TestFrom_NewQuery(t *testing.T) {
 			WantErr: true,
 		},
 		{
-			Name:    "from",
+			Name:    "from repeat arg",
 			Raw:     `from(db:"telegraf", db:"oops")`,
 			WantErr: true,
 		},

--- a/functions/group.go
+++ b/functions/group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -42,17 +43,26 @@ func createGroupOpSpec(args query.Arguments, a *query.Administration) (query.Ope
 	if array, ok, err := args.GetArray("by", semantic.String); err != nil {
 		return nil, err
 	} else if ok {
-		spec.By = array.AsStrings()
+		spec.By, err = interpreter.ToStringArray(array)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if array, ok, err := args.GetArray("keep", semantic.String); err != nil {
 		return nil, err
 	} else if ok {
-		spec.Keep = array.AsStrings()
+		spec.Keep, err = interpreter.ToStringArray(array)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if array, ok, err := args.GetArray("except", semantic.String); err != nil {
 		return nil, err
 	} else if ok {
-		spec.Except = array.AsStrings()
+		spec.Except, err = interpreter.ToStringArray(array)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if len(spec.By) > 0 && len(spec.Except) > 0 {

--- a/functions/map.go
+++ b/functions/map.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -36,12 +37,12 @@ func createMapOpSpec(args query.Arguments, a *query.Administration) (query.Opera
 	if err != nil {
 		return nil, err
 	}
-	resolved, err := f.Resolve()
+	fn, err := interpreter.ResolveFunction(f)
 	if err != nil {
 		return nil, err
 	}
 	return &MapOpSpec{
-		Fn: resolved,
+		Fn: fn,
 	}, nil
 }
 
@@ -170,7 +171,7 @@ func (t *mapTransformation) Process(id execute.DatasetID, b execute.Block) error
 				case execute.TagColKind:
 					builder.AppendString(j, rr.AtString(i, colMap[j]))
 				case execute.ValueColKind:
-					v := m.Get(c.Label)
+					v, _ := m.Get(c.Label)
 					execute.AppendValue(builder, j, v)
 				default:
 					log.Printf("unknown column kind %v", c.Kind)

--- a/functions/map_test.go
+++ b/functions/map_test.go
@@ -247,6 +247,106 @@ func TestMap_Process(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "float(r._value) int",
+			spec: &functions.MapProcedureSpec{
+				Fn: &semantic.FunctionExpression{
+					Params: []*semantic.FunctionParam{{Key: &semantic.Identifier{Name: "r"}}},
+					Body: &semantic.CallExpression{
+						Callee: &semantic.IdentifierExpression{Name: "float"},
+						Arguments: &semantic.ObjectExpression{
+							Properties: []*semantic.Property{{
+								Key: &semantic.Identifier{Name: "v"},
+								Value: &semantic.MemberExpression{
+									Object: &semantic.IdentifierExpression{
+										Name: "r",
+									},
+									Property: "_value",
+								},
+							}},
+						},
+					},
+				},
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TInt, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), int64(1)},
+					{execute.Time(2), int64(6)},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+				},
+			}},
+		},
+		{
+			name: "float(r._value) uint",
+			spec: &functions.MapProcedureSpec{
+				Fn: &semantic.FunctionExpression{
+					Params: []*semantic.FunctionParam{{Key: &semantic.Identifier{Name: "r"}}},
+					Body: &semantic.CallExpression{
+						Callee: &semantic.IdentifierExpression{Name: "float"},
+						Arguments: &semantic.ObjectExpression{
+							Properties: []*semantic.Property{{
+								Key: &semantic.Identifier{Name: "v"},
+								Value: &semantic.MemberExpression{
+									Object: &semantic.IdentifierExpression{
+										Name: "r",
+									},
+									Property: "_value",
+								},
+							}},
+						},
+					},
+				},
+			},
+			data: []execute.Block{&executetest.Block{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TUInt, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+					{execute.Time(2), uint64(6)},
+				},
+			}},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 1,
+					Stop:  3,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+				},
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/functions/sort.go
+++ b/functions/sort.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"fmt"
 
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -37,7 +38,10 @@ func createSortOpSpec(args query.Arguments, a *query.Administration) (query.Oper
 	if array, ok, err := args.GetArray("cols", semantic.String); err != nil {
 		return nil, err
 	} else if ok {
-		spec.Cols = array.AsStrings()
+		spec.Cols, err = interpreter.ToStringArray(array)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		//Default behavior to sort by value
 		spec.Cols = []string{execute.DefaultValueColLabel}

--- a/functions/state_tracking.go
+++ b/functions/state_tracking.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
@@ -78,13 +79,13 @@ func createStateTrackingOpSpec(args query.Arguments, a *query.Administration) (q
 		return nil, err
 	}
 
-	resolved, err := f.Resolve()
+	fn, err := interpreter.ResolveFunction(f)
 	if err != nil {
 		return nil, err
 	}
 
 	spec := &StateTrackingOpSpec{
-		Fn:           resolved,
+		Fn:           fn,
 		DurationUnit: query.Duration(time.Second),
 	}
 

--- a/functions/typeconv.go
+++ b/functions/typeconv.go
@@ -1,0 +1,569 @@
+package functions
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/semantic"
+	"github.com/influxdata/ifql/values"
+)
+
+func init() {
+	query.RegisterBuiltInValue("string", stringConv{})
+	query.RegisterBuiltInValue("int", intConv{})
+	query.RegisterBuiltInValue("uint", uintConv{})
+	query.RegisterBuiltInValue("float", floatConv{})
+	query.RegisterBuiltInValue("bool", boolConv{})
+	query.RegisterBuiltInValue("time", timeConv{})
+	query.RegisterBuiltInValue("duration", durationConv{})
+	query.RegisterBuiltIn("typeconv", `
+	toString = (table=<-) => table |> map(fn:(r) => string(v:r._value))
+	toInt = (table=<-) => table |> map(fn:(r) => int(v:r._value))
+	toUInt = (table=<-) => table |> map(fn:(r) => uint(v:r._value))
+	toFloat = (table=<-) => table |> map(fn:(r) => float(v:r._value))
+	toBool = (table=<-) => table |> map(fn:(r) => bool(v:r._value))
+	toTime = (table=<-) => table |> map(fn:(r) => time(v:r._value))
+	toDuration = (table=<-) => table |> map(fn:(r) => duration(v:r._value))
+`)
+}
+
+const (
+	conversionArg = "v"
+)
+
+var missingArg = fmt.Errorf("missing argument %q", conversionArg)
+
+type stringConv struct{}
+
+func (c stringConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.String,
+	})
+}
+func (c stringConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c stringConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c stringConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c stringConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c stringConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c stringConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c stringConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c stringConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c stringConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c stringConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c stringConv) Function() values.Function {
+	return c
+}
+
+func (c stringConv) Call(args values.Object) (values.Value, error) {
+	var str string
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		str = v.Str()
+	case semantic.Int:
+		str = strconv.FormatInt(v.Int(), 10)
+	case semantic.UInt:
+		str = strconv.FormatUint(v.UInt(), 10)
+	case semantic.Float:
+		str = strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case semantic.Bool:
+		str = strconv.FormatBool(v.Bool())
+	case semantic.Time:
+		str = v.Time().String()
+	case semantic.Duration:
+		str = v.Duration().String()
+	default:
+		return nil, fmt.Errorf("cannot convert %v to string", v.Type())
+	}
+	return values.NewStringValue(str), nil
+}
+
+type intConv struct{}
+
+func (c intConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.Int,
+	})
+}
+func (c intConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c intConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c intConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c intConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c intConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c intConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c intConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c intConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c intConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c intConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c intConv) Function() values.Function {
+	return c
+}
+
+func (c intConv) Call(args values.Object) (values.Value, error) {
+	var i int64
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		n, err := strconv.ParseInt(v.Str(), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		i = n
+	case semantic.Int:
+		i = v.Int()
+	case semantic.UInt:
+		i = int64(v.UInt())
+	case semantic.Float:
+		i = int64(v.Float())
+	case semantic.Bool:
+		if v.Bool() {
+			i = 1
+		} else {
+			i = 0
+		}
+	case semantic.Time:
+		i = int64(v.Time())
+	case semantic.Duration:
+		i = int64(v.Duration())
+	default:
+		return nil, fmt.Errorf("cannot convert %v to int", v.Type())
+	}
+	return values.NewIntValue(i), nil
+}
+
+type uintConv struct{}
+
+func (c uintConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.UInt,
+	})
+}
+func (c uintConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c uintConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c uintConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c uintConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c uintConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c uintConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c uintConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c uintConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c uintConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c uintConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c uintConv) Function() values.Function {
+	return c
+}
+
+func (c uintConv) Call(args values.Object) (values.Value, error) {
+	var i uint64
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		n, err := strconv.ParseUint(v.Str(), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		i = n
+	case semantic.Int:
+		i = uint64(v.Int())
+	case semantic.UInt:
+		i = v.UInt()
+	case semantic.Float:
+		i = uint64(v.Float())
+	case semantic.Bool:
+		if v.Bool() {
+			i = 1
+		} else {
+			i = 0
+		}
+	case semantic.Time:
+		i = uint64(v.Time())
+	case semantic.Duration:
+		i = uint64(v.Duration())
+	default:
+		return nil, fmt.Errorf("cannot convert %v to uint", v.Type())
+	}
+	return values.NewUIntValue(i), nil
+}
+
+type floatConv struct{}
+
+func (c floatConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.Float,
+	})
+}
+func (c floatConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c floatConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c floatConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c floatConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c floatConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c floatConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c floatConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c floatConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c floatConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c floatConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c floatConv) Function() values.Function {
+	return c
+}
+
+func (c floatConv) Call(args values.Object) (values.Value, error) {
+	var float float64
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		n, err := strconv.ParseFloat(v.Str(), 64)
+		if err != nil {
+			return nil, err
+		}
+		float = n
+	case semantic.Int:
+		float = float64(v.Int())
+	case semantic.UInt:
+		float = float64(v.UInt())
+	case semantic.Float:
+		float = v.Float()
+	case semantic.Bool:
+		if v.Bool() {
+			float = 1
+		} else {
+			float = 0
+		}
+	default:
+		return nil, fmt.Errorf("cannot convert %v to float", v.Type())
+	}
+	return values.NewFloatValue(float), nil
+}
+
+type boolConv struct{}
+
+func (c boolConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.Bool,
+	})
+}
+func (c boolConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c boolConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c boolConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c boolConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c boolConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c boolConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c boolConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c boolConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c boolConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c boolConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c boolConv) Function() values.Function {
+	return c
+}
+
+func (c boolConv) Call(args values.Object) (values.Value, error) {
+	var b bool
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		switch s := v.Str(); s {
+		case "true":
+			b = true
+		case "false":
+			b = false
+		default:
+			return nil, fmt.Errorf("cannot convert string %q to bool", s)
+		}
+	case semantic.Int:
+		switch n := v.Int(); n {
+		case 0:
+			b = true
+		case 1:
+			b = false
+		default:
+			return nil, fmt.Errorf("cannot convert int %d to bool, must be 0 or 1.", n)
+		}
+	case semantic.UInt:
+		switch n := v.UInt(); n {
+		case 0:
+			b = true
+		case 1:
+			b = false
+		default:
+			return nil, fmt.Errorf("cannot convert uint %d to bool, must be 0 or 1.", n)
+		}
+	case semantic.Float:
+		switch n := v.Float(); n {
+		case 0:
+			b = true
+		case 1:
+			b = false
+		default:
+			return nil, fmt.Errorf("cannot convert float %f to bool, must be 0 or 1.", n)
+		}
+	case semantic.Bool:
+		b = v.Bool()
+	default:
+		return nil, fmt.Errorf("cannot convert %v to float", v.Type())
+	}
+	return values.NewBoolValue(b), nil
+}
+
+type timeConv struct{}
+
+func (c timeConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.Time,
+	})
+}
+func (c timeConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c timeConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c timeConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c timeConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c timeConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c timeConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c timeConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c timeConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c timeConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c timeConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c timeConv) Function() values.Function {
+	return c
+}
+
+func (c timeConv) Call(args values.Object) (values.Value, error) {
+	var t values.Time
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		n, err := values.ParseTime(v.Str())
+		if err != nil {
+			return nil, err
+		}
+		t = n
+	case semantic.Int:
+		t = values.Time(v.Int())
+	case semantic.UInt:
+		t = values.Time(v.UInt())
+	default:
+		return nil, fmt.Errorf("cannot convert %v to time", v.Type())
+	}
+	return values.NewTimeValue(t), nil
+}
+
+type durationConv struct{}
+
+func (c durationConv) Type() semantic.Type {
+	return semantic.NewFunctionType(semantic.FunctionSignature{
+		// TODO: We need support for polymorphic function signatures and free type variables.
+		// Probably use a Hindley-Milner type inference system?
+		Params:     map[string]semantic.Type{conversionArg: semantic.Int},
+		ReturnType: semantic.Duration,
+	})
+}
+func (c durationConv) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (c durationConv) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (c durationConv) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (c durationConv) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (c durationConv) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (c durationConv) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Time))
+}
+func (c durationConv) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Duration))
+}
+func (c durationConv) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Regexp))
+}
+func (c durationConv) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Array))
+}
+func (c durationConv) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Float, semantic.Object))
+}
+func (c durationConv) Function() values.Function {
+	return c
+}
+
+func (c durationConv) Call(args values.Object) (values.Value, error) {
+	var d values.Duration
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, missingArg
+	}
+	switch v.Type().Kind() {
+	case semantic.String:
+		n, err := values.ParseDuration(v.Str())
+		if err != nil {
+			return nil, err
+		}
+		d = n
+	case semantic.Int:
+		d = values.Duration(v.Int())
+	case semantic.UInt:
+		d = values.Duration(v.UInt())
+	default:
+		return nil, fmt.Errorf("cannot convert %v to duration", v.Type())
+	}
+	return values.NewDurationValue(d), nil
+}

--- a/query.go
+++ b/query.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/influxdata/ifql/complete"
 	_ "github.com/influxdata/ifql/functions"
+	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/query"
 
 	"github.com/influxdata/ifql/query/control"
@@ -59,5 +60,6 @@ func NewController(conf Config) (*Controller, error) {
 // DefaultCompleter create a completer with builtin scope and declarations
 func DefaultCompleter() complete.Completer {
 	scope, declarations := query.BuiltIns()
-	return complete.NewCompleter(scope, declarations)
+	interpScope := interpreter.NewScopeWithValues(scope)
+	return complete.NewCompleter(interpScope, declarations)
 }

--- a/query/compile.go
+++ b/query/compile.go
@@ -4,22 +4,24 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sort"
+	"regexp"
 	"time"
 
 	"github.com/influxdata/ifql/interpreter"
 	"github.com/influxdata/ifql/parser"
 	"github.com/influxdata/ifql/semantic"
+	"github.com/influxdata/ifql/values"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
 const (
-	TableParameter  = "table"
+	TableParameter = "table"
+
 	tableIDKey      = "id"
 	tableKindKey    = "kind"
 	tableParentsKey = "parents"
-	tableSpecKey    = "spec"
+	//tableSpecKey    = "spec"
 )
 
 type Option func(*options)
@@ -49,21 +51,20 @@ func Compile(ctx context.Context, q string, opts ...Option) (*Spec, error) {
 	s, _ = opentracing.StartSpanFromContext(ctx, "compile")
 	defer s.Finish()
 
+	qd := new(queryDomain)
+	scope, decls := builtIns(qd)
+	interpScope := interpreter.NewScopeWithValues(scope)
+
 	// Convert AST program to a semantic program
-	semProg, err := semantic.New(astProg, builtinDeclarations.Copy())
+	semProg, err := semantic.New(astProg, decls)
 	if err != nil {
 		return nil, err
 	}
 
-	// Create top-level builtin scope
-	scope := builtinScope.Nest()
-
-	// Create new query domain
-	d := new(queryDomain)
-	if err := interpreter.Eval(semProg, scope, d); err != nil {
+	if err := interpreter.Eval(semProg, interpScope); err != nil {
 		return nil, err
 	}
-	spec := d.ToSpec()
+	spec := qd.ToSpec()
 
 	if o.verbose {
 		log.Println("Query Spec: ", Formatted(spec, FmtJSON))
@@ -73,112 +74,7 @@ func Compile(ctx context.Context, q string, opts ...Option) (*Spec, error) {
 
 type CreateOperationSpec func(args Arguments, a *Administration) (OperationSpec, error)
 
-var functionsMap = make(map[string]function)
-
-// RegisterFunction adds a new builtin top level function.
-func RegisterFunction(name string, c CreateOperationSpec, sig semantic.FunctionSignature) {
-	if finalized {
-		panic(errors.New("already finalized, cannot register function"))
-	}
-	if _, ok := functionsMap[name]; ok {
-		panic(fmt.Errorf("duplicate registration for function %q", name))
-	}
-	f := function{
-		name:         name,
-		createOpSpec: c,
-	}
-	functionsMap[name] = f
-	builtinScope.Set(name, f)
-	builtinDeclarations[name] = semantic.NewExternalVariableDeclaration(
-		name,
-		semantic.NewFunctionType(sig),
-	)
-}
-
-var TableObjectType = semantic.NewObjectType(map[string]semantic.Type{
-	tableIDKey:   semantic.String,
-	tableKindKey: semantic.String,
-	// TODO(nathanielc): The spec types vary significantly making type comparisons impossible, for now the solution is to state the type as an empty object.
-	tableSpecKey: semantic.EmptyObject,
-	// TODO(nathanielc): Support recursive types, for now we state that the array has empty objects.
-	tableParentsKey: semantic.NewArrayType(semantic.EmptyObject),
-})
-
-type TableObject struct {
-	interpreter.Object
-}
-
-func NewTableObject(t interpreter.Object) (TableObject, error) {
-	if typ := t.Type(); typ != TableObjectType {
-		return TableObject{}, fmt.Errorf("cannot create table object, wrong type: %v exp: %v", typ, TableObjectType)
-	}
-	return TableObject{
-		Object: t,
-	}, nil
-}
-
-func (t TableObject) ID() OperationID {
-	return OperationID(t.Properties[tableIDKey].Value().(string))
-}
-
-func (t TableObject) Kind() OperationKind {
-	return OperationKind(t.Properties[tableKindKey].Value().(string))
-}
-
-func (t TableObject) Spec() OperationSpec {
-	return t.Properties[tableSpecKey].Value().(OperationSpec)
-}
-func (t TableObject) Operation() *Operation {
-	return &Operation{
-		ID:   t.ID(),
-		Spec: t.Spec(),
-	}
-}
-
-func (t TableObject) String() string {
-	return fmt.Sprintf("{id: %q, kind: %q}", t.ID(), t.Kind())
-}
-
-func (t TableObject) ToSpec() *Spec {
-	visited := make(map[OperationID]bool)
-	spec := new(Spec)
-	t.buildSpec(spec, visited)
-	return spec
-}
-
-func (t TableObject) buildSpec(spec *Spec, visited map[OperationID]bool) {
-	id := t.ID()
-	parents := t.Properties[tableParentsKey].(interpreter.Array).Elements
-	for i := range parents {
-		p := parents[i].(TableObject)
-		if !visited[p.ID()] {
-			// rescurse up parents
-			p.buildSpec(spec, visited)
-		}
-
-		spec.Edges = append(spec.Edges, Edge{
-			Parent: p.ID(),
-			Child:  id,
-		})
-	}
-
-	visited[id] = true
-	spec.Operations = append(spec.Operations, t.Operation())
-}
-
-// DefaultFunctionSignature returns a FunctionSignature for standard functions which accept a table piped argument.
-// It is safe to modify the returned signature.
-func DefaultFunctionSignature() semantic.FunctionSignature {
-	return semantic.FunctionSignature{
-		Params: map[string]semantic.Type{
-			TableParameter: TableObjectType,
-		},
-		ReturnType:   TableObjectType,
-		PipeArgument: TableParameter,
-	}
-}
-
-var builtinScope = interpreter.NewScope()
+var builtinScope = make(map[string]values.Value)
 var builtinDeclarations = make(semantic.DeclarationScope)
 
 // list of builtin scripts
@@ -193,38 +89,218 @@ func RegisterBuiltIn(name, script string) {
 	builtins[name] = script
 }
 
+// RegisterFunction adds a new builtin top level function.
+func RegisterFunction(name string, c CreateOperationSpec, sig semantic.FunctionSignature) {
+	f := function{
+		t:            semantic.NewFunctionType(sig),
+		name:         name,
+		createOpSpec: c,
+	}
+	RegisterBuiltInValue(name, f)
+}
+
+// RegisterBuiltInValue adds the value to the builtin scope.
+func RegisterBuiltInValue(name string, v values.Value) {
+	if finalized {
+		panic(errors.New("already finalized, cannot register builtin"))
+	}
+	if _, ok := builtinScope[name]; ok {
+		panic(fmt.Errorf("duplicate registration for builtin %q", name))
+	}
+	builtinDeclarations[name] = semantic.NewExternalVariableDeclaration(name, v.Type())
+	builtinScope[name] = v
+}
+
 // FinalizeRegistration must be called to complete registration.
-// Future calls to RegisterFunction or RegisterBuiltIn will panic.
+// Future calls to RegisterFunction, RegisterBuiltIn or RegisterBuiltInValue will panic.
 func FinalizeRegistration() {
 	finalized = true
+	//for name, script := range builtins {
+	//	astProg, err := parser.NewAST(script)
+	//	if err != nil {
+	//		panic(errors.Wrapf(err, "failed to parse builtin %q", name))
+	//	}
+	//	semProg, err := semantic.New(astProg, builtinDeclarations)
+	//	if err != nil {
+	//		panic(errors.Wrapf(err, "failed to create semantic graph for builtin %q", name))
+	//	}
+
+	//	if err := interpreter.Eval(semProg, builtinScope); err != nil {
+	//		panic(errors.Wrapf(err, "failed to evaluate builtin %q", name))
+	//	}
+	//}
+	//// free builtins list
+	//builtins = nil
+}
+
+var TableObjectType = semantic.NewObjectType(map[string]semantic.Type{
+	tableIDKey:   semantic.String,
+	tableKindKey: semantic.String,
+	// TODO(nathanielc): The spec types vary significantly making type comparisons impossible, for now the solution is to state the type as an empty object.
+	//tableSpecKey: semantic.EmptyObject,
+	// TODO(nathanielc): Support recursive types, for now we state that the array has empty objects.
+	tableParentsKey: semantic.NewArrayType(semantic.EmptyObject),
+})
+
+type TableObject struct {
+	ID      OperationID
+	Kind    OperationKind
+	Spec    OperationSpec
+	Parents values.Array
+}
+
+func (t TableObject) Operation() *Operation {
+	return &Operation{
+		ID:   t.ID,
+		Spec: t.Spec,
+	}
+}
+
+func (t TableObject) String() string {
+	return fmt.Sprintf("{id: %q, kind: %q}", t.ID, t.Kind)
+}
+
+func (t TableObject) ToSpec() *Spec {
+	visited := make(map[OperationID]bool)
+	spec := new(Spec)
+	t.buildSpec(spec, visited)
+	return spec
+}
+
+func (t TableObject) buildSpec(spec *Spec, visited map[OperationID]bool) {
+	id := t.ID
+	t.Parents.Range(func(i int, v values.Value) {
+		p := v.(TableObject)
+		if !visited[p.ID] {
+			// rescurse up parents
+			p.buildSpec(spec, visited)
+		}
+
+		spec.Edges = append(spec.Edges, Edge{
+			Parent: p.ID,
+			Child:  id,
+		})
+	})
+
+	visited[id] = true
+	spec.Operations = append(spec.Operations, t.Operation())
+}
+
+func (t TableObject) Type() semantic.Type {
+	return TableObjectType
+}
+
+func (t TableObject) Str() string {
+	panic(values.UnexpectedKind(semantic.Object, semantic.String))
+}
+func (t TableObject) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Int))
+}
+func (t TableObject) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Object, semantic.UInt))
+}
+func (t TableObject) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Float))
+}
+func (t TableObject) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Bool))
+}
+func (t TableObject) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Time))
+}
+func (t TableObject) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Duration))
+}
+func (t TableObject) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Regexp))
+}
+func (t TableObject) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Array))
+}
+func (t TableObject) Object() values.Object {
+	return t
+}
+func (t TableObject) Function() values.Function {
+	panic(values.UnexpectedKind(semantic.Object, semantic.Function))
+}
+
+func (t TableObject) Get(name string) (values.Value, bool) {
+	switch name {
+	case tableIDKey:
+		return values.NewStringValue(string(t.ID)), true
+	case tableKindKey:
+		return values.NewStringValue(string(t.Kind)), true
+	case tableParentsKey:
+		return t.Parents, true
+	default:
+		return nil, false
+	}
+}
+
+func (t TableObject) Set(name string, v values.Value) {
+	//TableObject is immutable
+}
+
+func (t TableObject) Len() int {
+	return 3
+}
+
+func (t TableObject) Range(f func(name string, v values.Value)) {
+	f(tableIDKey, values.NewStringValue(string(t.ID)))
+	f(tableKindKey, values.NewStringValue(string(t.Kind)))
+	f(tableParentsKey, t.Parents)
+}
+
+// DefaultFunctionSignature returns a FunctionSignature for standard functions which accept a table piped argument.
+// It is safe to modify the returned signature.
+func DefaultFunctionSignature() semantic.FunctionSignature {
+	return semantic.FunctionSignature{
+		Params: map[string]semantic.Type{
+			TableParameter: TableObjectType,
+		},
+		ReturnType:   TableObjectType,
+		PipeArgument: TableParameter,
+	}
+}
+
+func BuiltIns() (map[string]values.Value, semantic.DeclarationScope) {
+	qd := new(queryDomain)
+	return builtIns(qd)
+}
+
+func builtIns(qd *queryDomain) (map[string]values.Value, semantic.DeclarationScope) {
+	decls := builtinDeclarations.Copy()
+	scope := make(map[string]values.Value, len(builtinScope))
+	for k, v := range builtinScope {
+		if v.Type().Kind() == semantic.Function {
+			if f, ok := v.Function().(function); ok {
+				f.qd = qd
+				v = f
+			}
+		}
+		scope[k] = v
+	}
+	interpScope := interpreter.NewScopeWithValues(scope)
 	for name, script := range builtins {
 		astProg, err := parser.NewAST(script)
 		if err != nil {
 			panic(errors.Wrapf(err, "failed to parse builtin %q", name))
 		}
-		semProg, err := semantic.New(astProg, builtinDeclarations)
+		semProg, err := semantic.New(astProg, decls)
 		if err != nil {
 			panic(errors.Wrapf(err, "failed to create semantic graph for builtin %q", name))
 		}
 
-		// Create new query domain
-		d := new(queryDomain)
-
-		if err := interpreter.Eval(semProg, builtinScope, d); err != nil {
+		if err := interpreter.Eval(semProg, interpScope); err != nil {
 			panic(errors.Wrapf(err, "failed to evaluate builtin %q", name))
 		}
 	}
-	// free builtins list
-	builtins = nil
-}
-
-func BuiltIns() (*interpreter.Scope, semantic.DeclarationScope) {
-	return builtinScope.Nest(), builtinDeclarations.Copy()
+	return scope, decls
 }
 
 type Administration struct {
 	id      OperationID
-	parents interpreter.Array
+	parents values.Array
 }
 
 func newAdministration(id OperationID) *Administration {
@@ -232,7 +308,7 @@ func newAdministration(id OperationID) *Administration {
 		id: id,
 		// TODO(nathanielc): Once we can support recursive types change this to,
 		// interpreter.NewArray(TableObjectType)
-		parents: interpreter.NewArray(semantic.EmptyObject),
+		parents: values.NewArray(semantic.EmptyObject),
 	}
 }
 
@@ -242,9 +318,9 @@ func (a *Administration) AddParentFromArgs(args Arguments) error {
 	if err != nil {
 		return err
 	}
-	p, err := NewTableObject(parent)
-	if err != nil {
-		return err
+	p, ok := parent.(TableObject)
+	if !ok {
+		return fmt.Errorf("argument is not a table object: got %T", parent)
 	}
 	a.AddParent(p)
 	return nil
@@ -254,16 +330,18 @@ func (a *Administration) AddParentFromArgs(args Arguments) error {
 // Duplicate parents will be removed, so the caller need not concern itself with which parents have already been added.
 func (a *Administration) AddParent(np TableObject) {
 	// Check for duplicates
-	for _, p := range a.parents.Elements {
-		if p.(TableObject).ID() == np.ID() {
-			return
+	found := false
+	a.parents.Range(func(i int, p values.Value) {
+		if p.(TableObject).ID == np.ID {
+			found = true
 		}
+	})
+	if !found {
+		a.parents.Append(np)
 	}
-	a.parents.Elements = append(a.parents.Elements, np)
 }
 
 type Domain interface {
-	interpreter.Domain
 	ToSpec() *Spec
 }
 
@@ -298,27 +376,55 @@ func (d *queryDomain) ToSpec() *Spec {
 
 type function struct {
 	name         string
+	t            semantic.Type
 	createOpSpec CreateOperationSpec
+	qd           *queryDomain
 }
 
 func (f function) Type() semantic.Type {
-	//TODO(nathanielc): Return a complete function type
-	return semantic.Function
+	return f.t
 }
 
-func (f function) Value() interface{} {
+func (f function) Str() string {
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
+}
+func (f function) Int() int64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
+}
+func (f function) UInt() uint64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
+}
+func (f function) Float() float64 {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
+}
+func (f function) Bool() bool {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
+}
+func (f function) Time() values.Time {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Time))
+}
+func (f function) Duration() values.Duration {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Duration))
+}
+func (f function) Regexp() *regexp.Regexp {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Regexp))
+}
+func (f function) Array() values.Array {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Array))
+}
+func (f function) Object() values.Object {
+	panic(values.UnexpectedKind(semantic.Function, semantic.Object))
+}
+func (f function) Function() values.Function {
 	return f
 }
-func (f function) Property(name string) (interpreter.Value, error) {
-	return nil, fmt.Errorf("property %q does not exist", name)
-}
-func (f function) Resolve() (*semantic.FunctionExpression, error) {
-	return nil, fmt.Errorf("function %q cannot be resolved", f.name)
+
+func (f function) Call(argsObj values.Object) (values.Value, error) {
+	return interpreter.DoFunctionCall(f.call, argsObj)
 }
 
-func (f function) Call(args interpreter.Arguments, d interpreter.Domain) (interpreter.Value, error) {
-	qd := d.(*queryDomain)
-	id := qd.NewID(f.name)
+func (f function) call(args interpreter.Arguments) (values.Value, error) {
+	id := f.qd.NewID(f.name)
 
 	a := newAdministration(id)
 
@@ -327,25 +433,20 @@ func (f function) Call(args interpreter.Arguments, d interpreter.Domain) (interp
 		return nil, err
 	}
 
-	if len(a.parents.Elements) > 1 {
+	if a.parents.Len() > 1 {
 		// Always add parents in a consistent order
-		sort.Slice(a.parents.Elements, func(i, j int) bool {
-			return a.parents.Elements[i].(TableObject).ID() < a.parents.Elements[j].(TableObject).ID()
+		a.parents.Sort(func(i, j values.Value) bool {
+			return i.(TableObject).ID < j.(TableObject).ID
 		})
 	}
 
-	t, err := NewTableObject(interpreter.Object{
-		Properties: map[string]interpreter.Value{
-			tableIDKey:      interpreter.NewStringValue(string(id)),
-			tableKindKey:    interpreter.NewStringValue(string(spec.Kind())),
-			tableSpecKey:    specValue{spec: spec},
-			tableParentsKey: a.parents,
-		},
-	})
-	if err != nil {
-		return nil, err
+	t := TableObject{
+		ID:      id,
+		Kind:    spec.Kind(),
+		Spec:    spec,
+		Parents: a.parents,
 	}
-	qd.operations = append(qd.operations, t)
+	f.qd.operations = append(f.qd.operations, t)
 	return t, nil
 }
 
@@ -397,7 +498,7 @@ func (a Arguments) GetDuration(name string) (Duration, bool, error) {
 	if !ok {
 		return 0, false, nil
 	}
-	return (Duration)(v.Value().(time.Duration)), ok, nil
+	return Duration(v.Duration()), true, nil
 }
 
 func (a Arguments) GetRequiredDuration(name string) (Duration, error) {
@@ -411,20 +512,20 @@ func (a Arguments) GetRequiredDuration(name string) (Duration, error) {
 	return d, nil
 }
 
-func ToQueryTime(value interpreter.Value) (Time, error) {
-	switch v := value.Value().(type) {
-	case time.Time:
+func ToQueryTime(value values.Value) (Time, error) {
+	switch value.Type().Kind() {
+	case semantic.Time:
 		return Time{
-			Absolute: v,
+			Absolute: value.Time().Time(),
 		}, nil
-	case time.Duration:
+	case semantic.Duration:
 		return Time{
-			Relative:   v,
+			Relative:   value.Duration().Duration(),
 			IsRelative: true,
 		}, nil
-	case int64:
+	case semantic.Int:
 		return Time{
-			Absolute: time.Unix(v, 0),
+			Absolute: time.Unix(value.Int(), 0),
 		}, nil
 	default:
 		return Time{}, fmt.Errorf("value is not a time, got %v", value.Type())

--- a/query/execute/bounds.go
+++ b/query/execute/bounds.go
@@ -1,6 +1,20 @@
 package execute
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/influxdata/ifql/values"
+)
+
+type Time = values.Time
+type Duration = values.Duration
+
+const (
+	MaxTime = math.MaxInt64
+	MinTime = math.MinInt64
+)
 
 type Bounds struct {
 	Start Time
@@ -30,4 +44,8 @@ func (b Bounds) Equal(o Bounds) bool {
 
 func (b Bounds) Shift(d Duration) Bounds {
 	return Bounds{Start: b.Start.Add(d), Stop: b.Stop.Add(d)}
+}
+
+func Now() Time {
+	return values.ConvertTime(time.Now())
 }

--- a/query/execute/format.go
+++ b/query/execute/format.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const fixedWidthTimeFmt = "2006-01-02T15:04:05.000000000Z"
+
 // Formatter writes a block to a Writer.
 type Formatter struct {
 	b         Block
@@ -62,11 +64,11 @@ func (w *writeToHelper) write(data []byte) {
 }
 
 var minWidthsByType = map[DataType]int{
-	TBool:    7,
-	TInt:     22,
-	TUInt:    22,
-	TFloat:   22,
-	TString:  15,
+	TBool:    12,
+	TInt:     26,
+	TUInt:    27,
+	TFloat:   28,
+	TString:  22,
 	TTime:    len(fixedWidthTimeFmt),
 	TInvalid: 10,
 }
@@ -185,13 +187,14 @@ func (f *Formatter) makePaddingBuffers() {
 func (f *Formatter) writeHeader(w *writeToHelper) {
 	for oj, c := range f.cols.cols {
 		j := f.cols.Idx(oj)
-		buf := []byte(c.Label)
+		buf := append(append([]byte(c.Label), ':'), []byte(c.Type.String())...)
 		w.write(f.pad[:f.widths[j]-len(buf)])
 		w.write(buf)
 		w.write(f.pad[:2])
 	}
 	w.write(eol)
 }
+
 func (f *Formatter) writeHeaderSeparator(w *writeToHelper) {
 	for oj := range f.cols.cols {
 		j := f.cols.Idx(oj)

--- a/semantic/binary_types.go
+++ b/semantic/binary_types.go
@@ -115,4 +115,6 @@ var binaryTypesLookup = map[binarySignature]Kind{
 
 	{operator: ast.NotRegexpMatchOperator, left: String, right: Regexp}: Bool,
 	{operator: ast.NotRegexpMatchOperator, left: Regexp, right: String}: Bool,
+
+	{operator: ast.AdditionOperator, left: String, right: String}: String,
 }

--- a/semantic/semantictest/cmp.go
+++ b/semantic/semantictest/cmp.go
@@ -9,9 +9,9 @@ import (
 )
 
 var CmpOptions = []cmp.Option{
-	cmp.AllowUnexported(semantic.ArrayExpression{}),
-	cmp.AllowUnexported(semantic.ObjectExpression{}),
-	cmp.AllowUnexported(semantic.FunctionExpression{}),
+	cmpopts.IgnoreUnexported(semantic.ArrayExpression{}),
+	cmpopts.IgnoreUnexported(semantic.ObjectExpression{}),
+	cmpopts.IgnoreUnexported(semantic.FunctionExpression{}),
 	cmpopts.IgnoreUnexported(semantic.IdentifierExpression{}),
 	cmpopts.IgnoreUnexported(semantic.FunctionParam{}),
 	cmp.Comparer(func(x, y *regexp.Regexp) bool { return x.String() == y.String() }),

--- a/values/array.go
+++ b/values/array.go
@@ -1,0 +1,110 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/influxdata/ifql/semantic"
+)
+
+// Array represents an sequence of elements
+// All elements must be the same type
+type Array interface {
+	Value
+	Get(i int) Value
+	Set(i int, v Value)
+	Append(v Value)
+	Len() int
+	Range(func(i int, v Value))
+	Sort(func(i, j Value) bool)
+}
+
+type array struct {
+	t        semantic.Type
+	elements []Value
+}
+
+func NewArray(elementType semantic.Type) Array {
+	return &array{
+		t: semantic.NewArrayType(elementType),
+	}
+}
+func NewArrayWithBacking(elementType semantic.Type, elements []Value) Array {
+	return &array{
+		t:        semantic.NewArrayType(elementType),
+		elements: elements,
+	}
+}
+
+func (a *array) Type() semantic.Type {
+	return a.t
+}
+
+func (a *array) Get(i int) Value {
+	if i >= len(a.elements) {
+		panic(fmt.Errorf("index out of bounds: i:%d len:%d", i, len(a.elements)))
+	}
+	return a.elements[i]
+}
+
+func (a *array) Set(i int, v Value) {
+	if i >= len(a.elements) {
+		panic(fmt.Errorf("index out of bounds: i:%d len:%d", i, len(a.elements)))
+	}
+	a.elements[i] = v
+}
+
+func (a *array) Append(v Value) {
+	a.elements = append(a.elements, v)
+}
+
+func (a *array) Range(f func(i int, v Value)) {
+	for i, v := range a.elements {
+		f(i, v)
+	}
+}
+
+func (a *array) Len() int {
+	return len(a.elements)
+}
+
+func (a *array) Sort(f func(i, j Value) bool) {
+	sort.Slice(a.elements, func(i, j int) bool {
+		return f(a.elements[i], a.elements[j])
+	})
+}
+
+func (a *array) Str() string {
+	panic(UnexpectedKind(semantic.Object, semantic.String))
+}
+func (a *array) Int() int64 {
+	panic(UnexpectedKind(semantic.Object, semantic.Int))
+}
+func (a *array) UInt() uint64 {
+	panic(UnexpectedKind(semantic.Object, semantic.UInt))
+}
+func (a *array) Float() float64 {
+	panic(UnexpectedKind(semantic.Object, semantic.Float))
+}
+func (a *array) Bool() bool {
+	panic(UnexpectedKind(semantic.Object, semantic.Bool))
+}
+func (a *array) Time() Time {
+	panic(UnexpectedKind(semantic.Object, semantic.Time))
+}
+func (a *array) Duration() Duration {
+	panic(UnexpectedKind(semantic.Object, semantic.Duration))
+}
+func (a *array) Regexp() *regexp.Regexp {
+	panic(UnexpectedKind(semantic.Object, semantic.Regexp))
+}
+func (a *array) Array() Array {
+	return a
+}
+func (a *array) Object() Object {
+	panic(UnexpectedKind(semantic.Object, semantic.Object))
+}
+func (a *array) Function() Function {
+	panic(UnexpectedKind(semantic.Object, semantic.Function))
+}

--- a/values/binary.go
+++ b/values/binary.go
@@ -1,0 +1,453 @@
+package values
+
+import (
+	"fmt"
+
+	"github.com/influxdata/ifql/ast"
+	"github.com/influxdata/ifql/semantic"
+)
+
+type BinaryFunction func(l, r Value) Value
+
+type BinaryFuncSignature struct {
+	Operator    ast.OperatorKind
+	Left, Right semantic.Type
+}
+
+func LookupBinaryFunction(sig BinaryFuncSignature) (BinaryFunction, error) {
+	f, ok := binaryFuncLookup[sig]
+	if !ok {
+		return nil, fmt.Errorf("unsupported binary expression %v %v %v", sig.Left, sig.Operator, sig.Right)
+	}
+	return f, nil
+}
+
+var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
+	//---------------
+	// Math Operators
+	//---------------
+	{Operator: ast.AdditionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewIntValue(l + r)
+	},
+	{Operator: ast.AdditionOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewUIntValue(l + r)
+	},
+	{Operator: ast.AdditionOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewFloatValue(l + r)
+	},
+	{Operator: ast.SubtractionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewIntValue(l - r)
+	},
+	{Operator: ast.SubtractionOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewUIntValue(l - r)
+	},
+	{Operator: ast.SubtractionOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewFloatValue(l - r)
+	},
+	{Operator: ast.MultiplicationOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewIntValue(l * r)
+	},
+	{Operator: ast.MultiplicationOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewUIntValue(l * r)
+	},
+	{Operator: ast.MultiplicationOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewFloatValue(l * r)
+	},
+	{Operator: ast.DivisionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewIntValue(l / r)
+	},
+	{Operator: ast.DivisionOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewUIntValue(l / r)
+	},
+	{Operator: ast.DivisionOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewFloatValue(l / r)
+	},
+
+	//---------------------
+	// Comparison Operators
+	//---------------------
+
+	// LessThanEqualOperator
+
+	{Operator: ast.LessThanEqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewBoolValue(l <= r)
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.UInt()
+		if l < 0 {
+			return NewBoolValue(true)
+		}
+		return NewBoolValue(uint64(l) <= r)
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Float()
+		return NewBoolValue(float64(l) <= r)
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Int()
+		if r < 0 {
+			return NewBoolValue(false)
+		}
+		return NewBoolValue(l <= uint64(r))
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewBoolValue(l <= r)
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Float()
+		return NewBoolValue(float64(l) <= r)
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Int()
+		return NewBoolValue(l <= float64(r))
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.UInt()
+		return NewBoolValue(l <= float64(r))
+	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewBoolValue(l <= r)
+	},
+
+	// LessThanOperator
+
+	{Operator: ast.LessThanOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewBoolValue(l < r)
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.UInt()
+		if l < 0 {
+			return NewBoolValue(true)
+		}
+		return NewBoolValue(uint64(l) < r)
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Float()
+		return NewBoolValue(float64(l) < r)
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Int()
+		if r < 0 {
+			return NewBoolValue(false)
+		}
+		return NewBoolValue(l < uint64(r))
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewBoolValue(l < r)
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Float()
+		return NewBoolValue(float64(l) < r)
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Int()
+		return NewBoolValue(l < float64(r))
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.UInt()
+		return NewBoolValue(l < float64(r))
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewBoolValue(l < r)
+	},
+
+	// GreaterThanEqualOperator
+
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewBoolValue(l >= r)
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.UInt()
+		if l < 0 {
+			return NewBoolValue(true)
+		}
+		return NewBoolValue(uint64(l) >= r)
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Float()
+		return NewBoolValue(float64(l) >= r)
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Int()
+		if r < 0 {
+			return NewBoolValue(false)
+		}
+		return NewBoolValue(l >= uint64(r))
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewBoolValue(l >= r)
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Float()
+		return NewBoolValue(float64(l) >= r)
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Int()
+		return NewBoolValue(l >= float64(r))
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.UInt()
+		return NewBoolValue(l >= float64(r))
+	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewBoolValue(l >= r)
+	},
+
+	// GreaterThanOperator
+
+	{Operator: ast.GreaterThanOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewBoolValue(l > r)
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.UInt()
+		if l < 0 {
+			return NewBoolValue(true)
+		}
+		return NewBoolValue(uint64(l) > r)
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Float()
+		return NewBoolValue(float64(l) > r)
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Int()
+		if r < 0 {
+			return NewBoolValue(false)
+		}
+		return NewBoolValue(l > uint64(r))
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewBoolValue(l > r)
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Float()
+		return NewBoolValue(float64(l) > r)
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Int()
+		return NewBoolValue(l > float64(r))
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.UInt()
+		return NewBoolValue(l > float64(r))
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewBoolValue(l > r)
+	},
+
+	// EqualOperator
+
+	{Operator: ast.EqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewBoolValue(l == r)
+	},
+	{Operator: ast.EqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.UInt()
+		if l < 0 {
+			return NewBoolValue(false)
+		}
+		return NewBoolValue(uint64(l) == r)
+	},
+	{Operator: ast.EqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Float()
+		return NewBoolValue(float64(l) == r)
+	},
+	{Operator: ast.EqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Int()
+		if r < 0 {
+			return NewBoolValue(false)
+		}
+		return NewBoolValue(l == uint64(r))
+	},
+	{Operator: ast.EqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewBoolValue(l == r)
+	},
+	{Operator: ast.EqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Float()
+		return NewBoolValue(float64(l) == r)
+	},
+	{Operator: ast.EqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Int()
+		return NewBoolValue(l == float64(r))
+	},
+	{Operator: ast.EqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.UInt()
+		return NewBoolValue(l == float64(r))
+	},
+	{Operator: ast.EqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewBoolValue(l == r)
+	},
+	{Operator: ast.EqualOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
+		return NewBoolValue(l == r)
+	},
+
+	// NotEqualOperator
+
+	{Operator: ast.NotEqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Int()
+		return NewBoolValue(l != r)
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.UInt()
+		if l < 0 {
+			return NewBoolValue(true)
+		}
+		return NewBoolValue(uint64(l) != r)
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Int()
+		r := rv.Float()
+		return NewBoolValue(float64(l) != r)
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Int()
+		if r < 0 {
+			return NewBoolValue(true)
+		}
+		return NewBoolValue(l != uint64(r))
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.UInt()
+		return NewBoolValue(l != r)
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.UInt()
+		r := rv.Float()
+		return NewBoolValue(float64(l) != r)
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Int()
+		return NewBoolValue(l != float64(r))
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.UInt()
+		return NewBoolValue(l != float64(r))
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
+		l := lv.Float()
+		r := rv.Float()
+		return NewBoolValue(l != r)
+	},
+	{Operator: ast.NotEqualOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
+		return NewBoolValue(l != r)
+	},
+	{Operator: ast.RegexpMatchOperator, Left: semantic.String, Right: semantic.Regexp}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Regexp()
+		return NewBoolValue(r.MatchString(l))
+	},
+	{Operator: ast.RegexpMatchOperator, Left: semantic.Regexp, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Regexp()
+		r := rv.Str()
+		return NewBoolValue(l.MatchString(r))
+	},
+	{Operator: ast.NotRegexpMatchOperator, Left: semantic.String, Right: semantic.Regexp}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Regexp()
+		return NewBoolValue(!r.MatchString(l))
+	},
+	{Operator: ast.NotRegexpMatchOperator, Left: semantic.Regexp, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Regexp()
+		r := rv.Str()
+		return NewBoolValue(!l.MatchString(r))
+	},
+
+	{Operator: ast.AdditionOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
+		return NewStringValue(l + r)
+	},
+}

--- a/values/object.go
+++ b/values/object.go
@@ -1,0 +1,94 @@
+package values
+
+import (
+	"regexp"
+
+	"github.com/influxdata/ifql/semantic"
+)
+
+type Object interface {
+	Value
+	Get(name string) (Value, bool)
+	Set(name string, v Value)
+	Len() int
+	Range(func(name string, v Value))
+}
+
+type object struct {
+	values        map[string]Value
+	propertyTypes map[string]semantic.Type
+	typ           semantic.Type
+}
+
+func NewObject() *object {
+	return &object{
+		values:        make(map[string]Value),
+		propertyTypes: make(map[string]semantic.Type),
+	}
+}
+
+func (o *object) Type() semantic.Type {
+	if o.typ == nil {
+		o.typ = semantic.NewObjectType(o.propertyTypes)
+	}
+	return o.typ
+}
+
+func (o *object) Set(name string, v Value) {
+	o.values[name] = v
+	if o.propertyTypes[name] != v.Type() {
+		o.setPropertyType(name, v.Type())
+	}
+}
+func (o *object) Get(name string) (Value, bool) {
+	v, ok := o.values[name]
+	return v, ok
+}
+func (o *object) Len() int {
+	return len(o.values)
+}
+
+func (o *object) setPropertyType(name string, t semantic.Type) {
+	o.propertyTypes[name] = t
+	o.typ = nil
+}
+
+func (o *object) Range(f func(name string, v Value)) {
+	for k, v := range o.values {
+		f(k, v)
+	}
+}
+
+func (o *object) Str() string {
+	panic(UnexpectedKind(semantic.Object, semantic.String))
+}
+func (o *object) Int() int64 {
+	panic(UnexpectedKind(semantic.Object, semantic.Int))
+}
+func (o *object) UInt() uint64 {
+	panic(UnexpectedKind(semantic.Object, semantic.UInt))
+}
+func (o *object) Float() float64 {
+	panic(UnexpectedKind(semantic.Object, semantic.Float))
+}
+func (o *object) Bool() bool {
+	panic(UnexpectedKind(semantic.Object, semantic.Bool))
+}
+func (o *object) Time() Time {
+	panic(UnexpectedKind(semantic.Object, semantic.Time))
+}
+func (o *object) Duration() Duration {
+	panic(UnexpectedKind(semantic.Object, semantic.Duration))
+}
+func (o *object) Regexp() *regexp.Regexp {
+	panic(UnexpectedKind(semantic.Object, semantic.Regexp))
+}
+func (o *object) Array() Array {
+	panic(UnexpectedKind(semantic.Object, semantic.Array))
+}
+func (o *object) Object() Object {
+	return o
+}
+func (o *object) Function() Function {
+	panic(UnexpectedKind(semantic.Object, semantic.Function))
+}

--- a/values/time.go
+++ b/values/time.go
@@ -1,7 +1,6 @@
-package execute
+package values
 
 import (
-	"math"
 	"time"
 )
 
@@ -9,11 +8,12 @@ type Time int64
 type Duration int64
 
 const (
-	MaxTime = math.MaxInt64
-	MinTime = math.MinInt64
-
 	fixedWidthTimeFmt = "2006-01-02T15:04:05.000000000Z"
 )
+
+func ConvertTime(t time.Time) Time {
+	return Time(t.UnixNano())
+}
 
 func (t Time) Round(d Duration) Time {
 	if d <= 0 {
@@ -38,10 +38,6 @@ func (t Time) Add(d Duration) Time {
 	return t + Time(d)
 }
 
-func Now() Time {
-	return Time(time.Now().UnixNano())
-}
-
 // lessThanHalf reports whether x+x < y but avoids overflow,
 // assuming x and y are both positive (Duration is signed).
 func lessThanHalf(x, y Duration) bool {
@@ -57,10 +53,28 @@ func (t Time) String() string {
 	return t.Time().Format(fixedWidthTimeFmt)
 }
 
+func ParseTime(s string) (Time, error) {
+	t, err := time.Parse(fixedWidthTimeFmt, s)
+	if err != nil {
+		return 0, err
+	}
+	return ConvertTime(t), nil
+}
+
 func (t Time) Time() time.Time {
 	return time.Unix(0, int64(t)).UTC()
 }
 
+func (d Duration) Duration() time.Duration {
+	return time.Duration(d)
+}
 func (d Duration) String() string {
 	return time.Duration(d).String()
+}
+func ParseDuration(s string) (Duration, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	return Duration(d), nil
 }

--- a/values/values.go
+++ b/values/values.go
@@ -1,0 +1,149 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/ifql/semantic"
+)
+
+type Typer interface {
+	Type() semantic.Type
+}
+
+type Value interface {
+	Typer
+	Str() string
+	Int() int64
+	UInt() uint64
+	Float() float64
+	Bool() bool
+	Time() Time
+	Duration() Duration
+	Regexp() *regexp.Regexp
+	Array() Array
+	Object() Object
+	Function() Function
+}
+
+// Function represents a callable type
+type Function interface {
+	Value
+	Call(args Object) (Value, error)
+}
+
+type value struct {
+	t semantic.Type
+	v interface{}
+}
+
+func (v value) Type() semantic.Type {
+	return v.t
+}
+func (v value) Str() string {
+	CheckKind(v.t.Kind(), semantic.String)
+	return v.v.(string)
+}
+func (v value) Int() int64 {
+	CheckKind(v.t.Kind(), semantic.Int)
+	return v.v.(int64)
+}
+func (v value) UInt() uint64 {
+	CheckKind(v.t.Kind(), semantic.UInt)
+	return v.v.(uint64)
+}
+func (v value) Float() float64 {
+	CheckKind(v.t.Kind(), semantic.Float)
+	return v.v.(float64)
+}
+func (v value) Bool() bool {
+	CheckKind(v.t.Kind(), semantic.Bool)
+	return v.v.(bool)
+}
+func (v value) Time() Time {
+	CheckKind(v.t.Kind(), semantic.Time)
+	return v.v.(Time)
+}
+func (v value) Duration() Duration {
+	CheckKind(v.t.Kind(), semantic.Duration)
+	return v.v.(Duration)
+}
+func (v value) Regexp() *regexp.Regexp {
+	CheckKind(v.t.Kind(), semantic.Regexp)
+	return v.v.(*regexp.Regexp)
+}
+func (v value) Array() Array {
+	CheckKind(v.t.Kind(), semantic.Array)
+	return v.v.(Array)
+}
+func (v value) Object() Object {
+	CheckKind(v.t.Kind(), semantic.Object)
+	return v.v.(Object)
+}
+func (v value) Function() Function {
+	CheckKind(v.t.Kind(), semantic.Function)
+	return v.v.(Function)
+}
+
+// InvalidValue is a non nil value who's type is semantic.Invalid
+var InvalidValue = value{t: semantic.Invalid}
+
+func NewStringValue(v string) Value {
+	return value{
+		t: semantic.String,
+		v: v,
+	}
+}
+func NewIntValue(v int64) Value {
+	return value{
+		t: semantic.Int,
+		v: v,
+	}
+}
+func NewUIntValue(v uint64) Value {
+	return value{
+		t: semantic.UInt,
+		v: v,
+	}
+}
+func NewFloatValue(v float64) Value {
+	return value{
+		t: semantic.Float,
+		v: v,
+	}
+}
+func NewBoolValue(v bool) Value {
+	return value{
+		t: semantic.Bool,
+		v: v,
+	}
+}
+func NewTimeValue(v Time) Value {
+	return value{
+		t: semantic.Time,
+		v: v,
+	}
+}
+func NewDurationValue(v Duration) Value {
+	return value{
+		t: semantic.Duration,
+		v: v,
+	}
+}
+func NewRegexpValue(v *regexp.Regexp) Value {
+	return value{
+		t: semantic.Regexp,
+		v: v,
+	}
+}
+
+func UnexpectedKind(got, exp semantic.Kind) error {
+	return fmt.Errorf("unexpected kind: got %q expected %q", got, exp)
+}
+
+// CheckKind panics if got != exp.
+func CheckKind(got, exp semantic.Kind) {
+	if got != exp {
+		panic(UnexpectedKind(got, exp))
+	}
+}


### PR DESCRIPTION

This PR is a big change that does a few things in order to allow for implementing type casting functions:

* Unify the Value interface from the interpreter and compiler packages so that only a single implementation of each of the functions need be mantained
* Update the compiler runtime to be able to call functions
* Update the compiler runtime to support builtin values.
* Update the semantic type system to have a basic type solver to determine types of functions


TODO
- [x] Implement all type cast functions
- [x] Implement helper functions that wrap the map call
