### PR TITLE
Add doc discussing the transpiler design

### DIFF
--- a/docs/Transpiler.md
+++ b/docs/Transpiler.md
@@ -1,0 +1,59 @@
+# Transpiler Design
+
+IFQL will support transpiling various other languages into query specification that can be executed.
+
+Executing a transpiled query involes two steps outside the normal execution process.
+
+1. Transpile the query to an query spec.
+2. Write the result in the desired format.
+
+The following interfaces found in the `crossexecute` package represent these concepts.
+
+```
+type QueryTranspiler interface {
+	Transpile(ctx context.Context, txt string) (*query.Spec, error)
+}
+
+type ResultWriter interface {
+	WriteTo(w io.Writer, results map[string]execute.Result) error
+}
+```
+
+Each different language/system need only implement a query transpiler and result writer.
+
+## Producing IFQL txt via transpilation
+
+The various transpilers only define the `somelang txt -> spec` transformation.
+In general the reverse process will be possible, `spec -> ifql txt`.
+Once any transpiler has been implemented then IFQL txt can be produced from that source language.
+
+
+## InfluxQL
+
+Specific to writing the InfluxQL transpiler there is a major problem to overcome:
+
+
+### How can the transpiler disambiguate fields and tags?
+
+The transpiler will need a service that can report whether an identifier is a field or a tag for a given measurement.
+The service will also need to be able to report which measurements exist for a given regexp pattern.
+With this extra information the transpiler should be able to process any InfluxQL query.
+
+
+#### Open Questions
+
+ * What to do about measurements that have different schemas and are queried as if they have the same schema?
+
+    ```
+    select sum("value") from /(a|b)/ where "c" == 'foo'
+    ```
+
+    `c` is a tag on measurement `a`.
+    `c` is a field on measurement `b`.
+
+    For 1.x does this error or return some result?
+
+ * Does a query spec contain enough information to convert 2.0 results into InfluxQL 1.x result JSON?
+     The final table wil contain the correct column names etc to produce the correct JSON output.
+     IFQL Table -> InfluxQL JSON
+

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -95,7 +95,6 @@ func (c *Controller) createQuery(ctx context.Context) *Query {
 		c:         c,
 		now:       time.Now().UTC(),
 		ready:     ready,
-		Ready:     ready,
 		parentCtx: cctx,
 		cancel:    cancel,
 	}
@@ -259,11 +258,7 @@ type Query struct {
 
 	err error
 
-	ready chan<- map[string]execute.Result
-	// Ready is a channel that will deliver the query results.
-	// The channel may be closed before any results arrive, in which case the query should be
-	// inspected for an error using Err().
-	Ready <-chan map[string]execute.Result
+	ready chan map[string]execute.Result
 
 	mu     sync.Mutex
 	state  State
@@ -306,6 +301,13 @@ func (q *Query) Cancel() {
 	// This allows for receiving from the Ready channel in the same goroutine
 	// that has called defer q.Done()
 	q.finish()
+}
+
+// Ready returns a channel that will deliver the query results.
+// Its possible that the channel is closed before any results arrive, in which case the query should be
+// inspected for an error using Err().
+func (q *Query) Ready() <-chan map[string]execute.Result {
+	return q.ready
 }
 
 // finish informs the controller and the Ready channel that the query is finished.

--- a/query/crossexecute/execute.go
+++ b/query/crossexecute/execute.go
@@ -1,0 +1,45 @@
+package crossexecute
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/influxdata/ifql/query"
+	"github.com/influxdata/ifql/query/control"
+	"github.com/influxdata/ifql/query/execute"
+)
+
+type QueryTranspiler interface {
+	Transpile(ctx context.Context, txt string) (*query.Spec, error)
+}
+
+type ResultWriter interface {
+	WriteTo(w io.Writer, results map[string]execute.Result) error
+}
+
+type Querier interface {
+	Query(ctx context.Context, spec *query.Spec) (*control.Query, error)
+}
+
+func CrossExecute(ctx context.Context, q string, querier Querier, transpiler QueryTranspiler, writer ResultWriter, w io.Writer) error {
+	spec, err := transpiler.Transpile(ctx, q)
+	if err != nil {
+		return err
+	}
+	query, err := querier.Query(ctx, spec)
+	if err != nil {
+		return err
+	}
+	defer query.Done()
+
+	select {
+	case <-ctx.Done():
+		return errors.New("context done before query completed")
+	case results, ok := <-query.Ready():
+		if !ok {
+			return query.Err()
+		}
+		return writer.WriteTo(w, results)
+	}
+}

--- a/query/crossexecute/influxql/transpiler.go
+++ b/query/crossexecute/influxql/transpiler.go
@@ -1,0 +1,28 @@
+package influxql
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/influxdata/ifql/query"
+)
+
+type Transpiler struct {
+	schema Schema
+}
+
+func (t *Transpiler) Transpile(ctx context.Context, txt string) (*query.Spec, error) {
+	panic("not implemented")
+}
+
+type Type int
+
+const (
+	Field Type = iota
+	Tag
+)
+
+type Schema interface {
+	MeasurementsForPattern(pattern *regexp.Regexp) []string
+	Type(measurement, id string) Type
+}

--- a/query/crossexecute/influxql/writer.go
+++ b/query/crossexecute/influxql/writer.go
@@ -1,0 +1,99 @@
+package influxql
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/ifql/query/execute"
+)
+
+type Writer struct{}
+
+func (Writer) WriteTo(w io.Writer, results map[string]execute.Result) error {
+	// TODO: This code was copy pasted from the hackathon branch that enabled Chronograf to talk to IFQL.
+	// It may need a refactor and it will tests to ensure that it accurately transforms the data to the correct format.
+	resp := response{
+		Results: make([]result, len(results)),
+	}
+
+	// This process needs to be deterministic.
+	// Process results in lexigraphical order.
+	order := make([]string, 0, len(results))
+	for name := range results {
+		order = append(order, name)
+	}
+	sort.Strings(order)
+
+	for i, name := range order {
+		r := results[name]
+		blocks := r.Blocks()
+		seriesID := 0
+		result := result{}
+		err := blocks.Do(func(b execute.Block) error {
+			s := series{Tags: b.Tags()}
+			for _, c := range b.Cols() {
+				if !c.Common {
+					s.Columns = append(s.Columns, c.Label)
+				}
+			}
+			seriesID++
+			s.Name = strconv.Itoa(seriesID)
+			times := b.Times()
+			times.DoTime(func(ts []execute.Time, rr execute.RowReader) {
+				for i := range ts {
+					var v []interface{}
+					for j, c := range rr.Cols() {
+						if c.Common {
+							continue
+						}
+						switch c.Type {
+						case execute.TFloat:
+							v = append(v, rr.AtFloat(i, j))
+						case execute.TInt:
+							v = append(v, rr.AtInt(i, j))
+						case execute.TString:
+							v = append(v, rr.AtString(i, j))
+						case execute.TUInt:
+							v = append(v, rr.AtUInt(i, j))
+						case execute.TBool:
+							v = append(v, rr.AtBool(i, j))
+						case execute.TTime:
+							v = append(v, rr.AtTime(i, j)/execute.Time(time.Second))
+						default:
+							v = append(v, "unknown")
+						}
+					}
+					s.Values = append(s.Values, v)
+				}
+			})
+			result.Series = append(result.Series, s)
+			return nil
+		})
+		if err != nil {
+			log.Println("Error iterating through results:", err)
+		}
+		resp.Results[i] = result
+	}
+
+	return json.NewEncoder(w).Encode(resp)
+}
+
+type response struct {
+	Results []result `json:"results"`
+	Err     string   `json:"err"`
+}
+
+type result struct {
+	Series []series `json:"series"`
+}
+
+type series struct {
+	Name    string            `json:"name"`
+	Columns []string          `json:"columns"`
+	Tags    map[string]string `json:"tags"`
+	Values  [][]interface{}   `json:"values"`
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -195,7 +195,7 @@ func (r *REPL) doQuery(spec *query.Spec) error {
 	}
 	defer q.Done()
 
-	results, ok := <-q.Ready
+	results, ok := <-q.Ready()
 	if !ok {
 		err := q.Err()
 		return err


### PR DESCRIPTION
This PR does two things:

* Adds a doc disussing the transpiler design
* Adds a `crossexecute` package which defines interfaces and their use for being able to transpile and execute any queries.


