### PR TITLE
Make aggregates and selecotrs a one-to-one operations on tables

### DIFF
--- a/functions/count.go
+++ b/functions/count.go
@@ -107,7 +107,7 @@ func createCountTransformation(id execute.DatasetID, mode execute.AccumulationMo
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
 
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), new(CountAgg), s.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(CountAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/cumulative_sum.go
+++ b/functions/cumulative_sum.go
@@ -101,13 +101,13 @@ func (t *cumulativeSumTransformation) Process(id execute.DatasetID, b execute.Bl
 				case execute.ValueColKind:
 					switch c.Type {
 					case execute.TInt:
-						cumSum := cumulativeSums[j].addInt(rr.AtInt(i,j))
+						cumSum := cumulativeSums[j].addInt(rr.AtInt(i, j))
 						builder.AppendInt(j, cumSum)
 					case execute.TUInt:
-						cumSum := cumulativeSums[j].addUInt(rr.AtUInt(i,j))
+						cumSum := cumulativeSums[j].addUInt(rr.AtUInt(i, j))
 						builder.AppendUInt(j, cumSum)
 					case execute.TFloat:
-						cumSum := cumulativeSums[j].addFloat(rr.AtFloat(i,j))
+						cumSum := cumulativeSums[j].addFloat(rr.AtFloat(i, j))
 						builder.AppendFloat(j, cumSum)
 					case execute.TBool:
 						builder.AppendBool(j, rr.AtBool(i, j))
@@ -134,8 +134,8 @@ func (t *cumulativeSumTransformation) Finish(id execute.DatasetID, err error) {
 }
 
 type cumulativeSum struct {
-	intVal	 int64
-	uintVal	 uint64
+	intVal   int64
+	uintVal  uint64
 	floatVal float64
 }
 

--- a/functions/cumulative_sum_test.go
+++ b/functions/cumulative_sum_test.go
@@ -226,9 +226,9 @@ func TestCumulativeSum_Process(t *testing.T) {
 					{Label: "t", Type: execute.TString, Kind: execute.TagColKind},
 				},
 				Data: [][]interface{}{
-					{execute.Time(0), int64(2),  "tag0"},
-					{execute.Time(1), int64(3),  "tag0"},
-					{execute.Time(2), int64(6),  "tag1"},
+					{execute.Time(0), int64(2), "tag0"},
+					{execute.Time(1), int64(3), "tag0"},
+					{execute.Time(2), int64(6), "tag1"},
 					{execute.Time(3), int64(10), "tag1"},
 					{execute.Time(4), int64(12), "tag0"},
 					{execute.Time(5), int64(18), "tag0"},

--- a/functions/first.go
+++ b/functions/first.go
@@ -117,7 +117,7 @@ func createFirstTransformation(id execute.DatasetID, mode execute.AccumulationMo
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, a.Bounds(), new(FirstSelector), ps.SelectorConfig, a.Allocator())
+	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, new(FirstSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/last.go
+++ b/functions/last.go
@@ -117,7 +117,7 @@ func createLastTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, a.Bounds(), new(LastSelector), ps.SelectorConfig, a.Allocator())
+	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(LastSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/max.go
+++ b/functions/max.go
@@ -81,7 +81,7 @@ func createMaxTransformation(id execute.DatasetID, mode execute.AccumulationMode
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, a.Bounds(), new(MaxSelector), ps.SelectorConfig, a.Allocator())
+	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(MaxSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/mean.go
+++ b/functions/mean.go
@@ -76,7 +76,7 @@ func createMeanTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), new(MeanAgg), s.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(MeanAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/min.go
+++ b/functions/min.go
@@ -81,7 +81,7 @@ func createMinTransformation(id execute.DatasetID, mode execute.AccumulationMode
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, a.Bounds(), new(MinSelector), ps.SelectorConfig, a.Allocator())
+	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(MinSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/percentile.go
+++ b/functions/percentile.go
@@ -159,7 +159,7 @@ func createPercentileTransformation(id execute.DatasetID, mode execute.Accumulat
 		Quantile:    ps.Percentile,
 		Compression: ps.Compression,
 	}
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), agg, ps.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, agg, ps.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 
@@ -214,7 +214,7 @@ func createExactPercentileTransformation(id execute.DatasetID, mode execute.Accu
 	agg := &ExactPercentileAgg{
 		Quantile: ps.Percentile,
 	}
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), agg, ps.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, agg, ps.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/sample.go
+++ b/functions/sample.go
@@ -114,7 +114,7 @@ func createSampleTransformation(id execute.DatasetID, mode execute.AccumulationM
 		N:   int(ps.N),
 		Pos: int(ps.Pos),
 	}
-	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, a.Bounds(), ss, ps.SelectorConfig, a.Allocator())
+	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, ss, ps.SelectorConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/skew.go
+++ b/functions/skew.go
@@ -76,7 +76,7 @@ func createSkewTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), new(SkewAgg), s.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(SkewAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/spread.go
+++ b/functions/spread.go
@@ -78,7 +78,7 @@ func createSpreadTransformation(id execute.DatasetID, mode execute.AccumulationM
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
 
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), new(SpreadAgg), s.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(SpreadAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/stddev.go
+++ b/functions/stddev.go
@@ -74,7 +74,7 @@ func createStddevTransformation(id execute.DatasetID, mode execute.AccumulationM
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), new(StddevAgg), s.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(StddevAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/sum.go
+++ b/functions/sum.go
@@ -104,7 +104,7 @@ func createSumTransformation(id execute.DatasetID, mode execute.AccumulationMode
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
 
-	t, d := execute.NewAggregateTransformationAndDataset(id, mode, a.Bounds(), new(SumAgg), s.AggregateConfig, a.Allocator())
+	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(SumAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil
 }
 

--- a/functions/window.go
+++ b/functions/window.go
@@ -2,11 +2,14 @@ package functions
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/influxdata/ifql/query"
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
 	"github.com/influxdata/ifql/semantic"
+	"github.com/influxdata/ifql/values"
+	"github.com/pkg/errors"
 )
 
 const WindowKind = "window"
@@ -19,6 +22,8 @@ type WindowOpSpec struct {
 	Triggering query.TriggerSpec `json:"triggering"`
 }
 
+var infinityVar = values.NewDurationValue(math.MaxInt64)
+
 var windowSignature = query.DefaultFunctionSignature()
 
 func init() {
@@ -29,6 +34,7 @@ func init() {
 
 	query.RegisterFunction(WindowKind, createWindowOpSpec, windowSignature)
 	query.RegisterOpSpec(WindowKind, newWindowOp)
+	query.RegisterBuiltInValue("inf", infinityVar)
 	plan.RegisterProcedureSpec(WindowKind, newWindowProcedure, WindowKind)
 	execute.RegisterTransformation(WindowKind, createWindowTransformation)
 }
@@ -64,9 +70,9 @@ func createWindowOpSpec(args query.Arguments, a *query.Administration) (query.Op
 		spec.Start = start
 	}
 
-	//if !everySet && !periodSet {
-	//	return nil, errors.New(`window function requires at least one of "every" or "period" to be set`)
-	//}
+	if !everySet && !periodSet {
+		return nil, errors.New(`window function requires at least one of "every" or "period" to be set`)
+	}
 
 	// Apply defaults
 	if !everySet {
@@ -213,9 +219,6 @@ func (t *fixedWindowTransformation) Process(id execute.DatasetID, b execute.Bloc
 }
 
 func (t *fixedWindowTransformation) getWindowBounds(now execute.Time) []execute.Bounds {
-	if t.w.Every == 0 && t.w.Period == 0 {
-		return []execute.Bounds{t.bounds}
-	}
 	stop := now.Truncate(t.w.Every) + execute.Time(t.offset)
 	if now >= stop {
 		stop += execute.Time(t.w.Every)

--- a/functions/window.go
+++ b/functions/window.go
@@ -7,7 +7,6 @@ import (
 	"github.com/influxdata/ifql/query/execute"
 	"github.com/influxdata/ifql/query/plan"
 	"github.com/influxdata/ifql/semantic"
-	"github.com/pkg/errors"
 )
 
 const WindowKind = "window"
@@ -65,9 +64,10 @@ func createWindowOpSpec(args query.Arguments, a *query.Administration) (query.Op
 		spec.Start = start
 	}
 
-	if !everySet && !periodSet {
-		return nil, errors.New(`window function requires at least one of "every" or "period" to be set`)
-	}
+	//if !everySet && !periodSet {
+	//	return nil, errors.New(`window function requires at least one of "every" or "period" to be set`)
+	//}
+
 	// Apply defaults
 	if !everySet {
 		spec.Every = spec.Period
@@ -213,6 +213,9 @@ func (t *fixedWindowTransformation) Process(id execute.DatasetID, b execute.Bloc
 }
 
 func (t *fixedWindowTransformation) getWindowBounds(now execute.Time) []execute.Bounds {
+	if t.w.Every == 0 && t.w.Period == 0 {
+		return []execute.Bounds{t.bounds}
+	}
 	stop := now.Truncate(t.w.Every) + execute.Time(t.offset)
 	if now >= stop {
 		stop += execute.Time(t.w.Every)

--- a/query/execute/aggregate.go
+++ b/query/execute/aggregate.go
@@ -3,10 +3,9 @@ package execute
 import "github.com/influxdata/ifql/query"
 
 type aggregateTransformation struct {
-	d      Dataset
-	cache  BlockBuilderCache
-	bounds Bounds
-	agg    Aggregate
+	d     Dataset
+	cache BlockBuilderCache
+	agg   Aggregate
 
 	config AggregateConfig
 }
@@ -24,20 +23,19 @@ func (c *AggregateConfig) ReadArgs(args query.Arguments) error {
 	return nil
 }
 
-func NewAggregateTransformation(d Dataset, c BlockBuilderCache, bounds Bounds, agg Aggregate, config AggregateConfig) *aggregateTransformation {
+func NewAggregateTransformation(d Dataset, c BlockBuilderCache, agg Aggregate, config AggregateConfig) *aggregateTransformation {
 	return &aggregateTransformation{
 		d:      d,
 		cache:  c,
-		bounds: bounds,
 		agg:    agg,
 		config: config,
 	}
 }
 
-func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, bounds Bounds, agg Aggregate, config AggregateConfig, a *Allocator) (*aggregateTransformation, Dataset) {
+func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, agg Aggregate, config AggregateConfig, a *Allocator) (*aggregateTransformation, Dataset) {
 	cache := NewBlockBuilderCache(a)
 	d := NewDataset(id, mode, cache)
-	return NewAggregateTransformation(d, cache, bounds, agg, config), d
+	return NewAggregateTransformation(d, cache, agg, config), d
 }
 
 func (t *aggregateTransformation) RetractBlock(id DatasetID, meta BlockMetadata) error {
@@ -47,10 +45,7 @@ func (t *aggregateTransformation) RetractBlock(id DatasetID, meta BlockMetadata)
 }
 
 func (t *aggregateTransformation) Process(id DatasetID, b Block) error {
-	builder, new := t.cache.BlockBuilder(blockMetadata{
-		bounds: t.bounds,
-		tags:   b.Tags(),
-	})
+	builder, new := t.cache.BlockBuilder(b)
 	if new {
 		cols := b.Cols()
 		for j, c := range cols {

--- a/query/execute/selector_test.go
+++ b/query/execute/selector_test.go
@@ -15,17 +15,12 @@ func TestRowSelector_Process(t *testing.T) {
 	// All test cases use a simple MinSelector
 	testCases := []struct {
 		name           string
-		bounds         execute.Bounds
 		selectorConfig execute.SelectorConfig
 		data           []*executetest.Block
-		want           func(b execute.Bounds) []*executetest.Block
+		want           []*executetest.Block
 	}{
 		{
 			name: "single",
-			bounds: execute.Bounds{
-				Start: 0,
-				Stop:  100,
-			},
 			data: []*executetest.Block{{
 				Bnds: execute.Bounds{
 					Start: 0,
@@ -48,28 +43,25 @@ func TestRowSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(100), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(100), 0.0},
+				},
+			}},
 		},
 		{
 			name: "single useStartTime",
 			selectorConfig: execute.SelectorConfig{
 				UseStartTime: true,
 			},
-			bounds: execute.Bounds{
-				Start: 0,
-				Stop:  100,
-			},
 			data: []*executetest.Block{{
 				Bnds: execute.Bounds{
 					Start: 0,
@@ -92,28 +84,25 @@ func TestRowSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(0), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), 0.0},
+				},
+			}},
 		},
 		{
 			name: "single useRowTime",
 			selectorConfig: execute.SelectorConfig{
 				UseRowTime: true,
 			},
-			bounds: execute.Bounds{
-				Start: 0,
-				Stop:  100,
-			},
 			data: []*executetest.Block{{
 				Bnds: execute.Bounds{
 					Start: 0,
@@ -136,27 +125,24 @@ func TestRowSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(0), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), 0.0},
+				},
+			}},
 		},
 		{
 			name: "single custom column",
 			selectorConfig: execute.SelectorConfig{
 				Column: "x",
-			},
-			bounds: execute.Bounds{
-				Start: 0,
-				Stop:  100,
 			},
 			data: []*executetest.Block{{
 				Bnds: execute.Bounds{
@@ -180,25 +166,22 @@ func TestRowSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "x", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(100), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "x", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(100), 0.0},
+				},
+			}},
 		},
 		{
 			name: "multiple blocks",
-			bounds: execute.Bounds{
-				Start: 0,
-				Stop:  200,
-			},
 			data: []*executetest.Block{
 				{
 					Bnds: execute.Bounds{
@@ -245,28 +228,39 @@ func TestRowSelector_Process(t *testing.T) {
 					},
 				},
 			},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
+			want: []*executetest.Block{
+				{
+					Bnds: execute.Bounds{
+						Start: 0,
+						Stop:  100,
+					},
 					ColMeta: []execute.ColMeta{
 						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
 						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
 					},
 					Data: [][]interface{}{
 						{execute.Time(100), 0.0},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 100,
+						Stop:  200,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					},
+					Data: [][]interface{}{
 						{execute.Time(200), 10.0},
 					},
-				}}
+				},
 			},
 		},
 		{
 			name: "multiple blocks with tags and useRowTime",
 			selectorConfig: execute.SelectorConfig{
 				UseRowTime: true,
-			},
-			bounds: execute.Bounds{
-				Start: 0,
-				Stop:  200,
 			},
 			data: []*executetest.Block{
 				{
@@ -366,35 +360,67 @@ func TestRowSelector_Process(t *testing.T) {
 					},
 				},
 			},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{
-					{
-						Bnds: b,
-						ColMeta: []execute.ColMeta{
-							{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-							{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-							{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
-							{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
-						},
-						Data: [][]interface{}{
-							{execute.Time(40), 1.0, "a", "x"},
-							{execute.Time(160), 11.0, "a", "y"},
-						},
+			want: []*executetest.Block{
+				{
+					Bnds: execute.Bounds{
+						Start: 0,
+						Stop:  100,
 					},
-					{
-						Bnds: b,
-						ColMeta: []execute.ColMeta{
-							{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-							{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-							{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
-							{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
-						},
-						Data: [][]interface{}{
-							{execute.Time(90), 1.3, "b", "y"},
-							{execute.Time(110), 11.3, "b", "x"},
-						},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
 					},
-				}
+					Data: [][]interface{}{
+						{execute.Time(40), 1.0, "a", "x"},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 100,
+						Stop:  200,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
+					},
+					Data: [][]interface{}{
+						{execute.Time(160), 11.0, "a", "y"},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 0,
+						Stop:  100,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
+					},
+					Data: [][]interface{}{
+						{execute.Time(90), 1.3, "b", "y"},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 100,
+						Stop:  200,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
+					},
+					Data: [][]interface{}{
+						{execute.Time(110), 11.3, "b", "x"},
+					},
+				},
 			},
 		},
 	}
@@ -405,7 +431,7 @@ func TestRowSelector_Process(t *testing.T) {
 			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
-			selector := execute.NewRowSelectorTransformation(d, c, tc.bounds, new(functions.MinSelector), tc.selectorConfig)
+			selector := execute.NewRowSelectorTransformation(d, c, new(functions.MinSelector), tc.selectorConfig)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {
@@ -414,14 +440,13 @@ func TestRowSelector_Process(t *testing.T) {
 				}
 			}
 
-			want := tc.want(tc.bounds)
 			got := executetest.BlocksFromCache(c)
 
 			sort.Sort(executetest.SortedBlocks(got))
-			sort.Sort(executetest.SortedBlocks(want))
+			sort.Sort(executetest.SortedBlocks(tc.want))
 
-			if !cmp.Equal(want, got, cmpopts.EquateNaNs()) {
-				t.Errorf("unexpected blocks -want/+got\n%s", cmp.Diff(want, got))
+			if !cmp.Equal(tc.want, got, cmpopts.EquateNaNs()) {
+				t.Errorf("unexpected blocks -want/+got\n%s", cmp.Diff(tc.want, got))
 			}
 		})
 	}
@@ -434,7 +459,7 @@ func TestIndexSelector_Process(t *testing.T) {
 		bounds         execute.Bounds
 		selectorConfig execute.SelectorConfig
 		data           []*executetest.Block
-		want           func(b execute.Bounds) []*executetest.Block
+		want           []*executetest.Block
 	}{
 		{
 			name: "single",
@@ -464,18 +489,19 @@ func TestIndexSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(100), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(100), 0.0},
+				},
+			}},
 		},
 		{
 			name: "single useStartTime",
@@ -508,18 +534,19 @@ func TestIndexSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(0), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), 0.0},
+				},
+			}},
 		},
 		{
 			name: "single useRowTime",
@@ -552,18 +579,19 @@ func TestIndexSelector_Process(t *testing.T) {
 					{execute.Time(90), 9.0},
 				},
 			}},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
-					ColMeta: []execute.ColMeta{
-						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-					},
-					Data: [][]interface{}{
-						{execute.Time(0), 0.0},
-					},
-				}}
-			},
+			want: []*executetest.Block{{
+				Bnds: execute.Bounds{
+					Start: 0,
+					Stop:  100,
+				},
+				ColMeta: []execute.ColMeta{
+					{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+					{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), 0.0},
+				},
+			}},
 		},
 		{
 			name: "multiple blocks",
@@ -617,18 +645,33 @@ func TestIndexSelector_Process(t *testing.T) {
 					},
 				},
 			},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{{
-					Bnds: b,
+			want: []*executetest.Block{
+				{
+					Bnds: execute.Bounds{
+						Start: 0,
+						Stop:  100,
+					},
 					ColMeta: []execute.ColMeta{
 						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
 						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
 					},
 					Data: [][]interface{}{
 						{execute.Time(100), 0.0},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 100,
+						Stop:  200,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+					},
+					Data: [][]interface{}{
 						{execute.Time(200), 10.0},
 					},
-				}}
+				},
 			},
 		},
 		{
@@ -738,35 +781,67 @@ func TestIndexSelector_Process(t *testing.T) {
 					},
 				},
 			},
-			want: func(b execute.Bounds) []*executetest.Block {
-				return []*executetest.Block{
-					{
-						Bnds: b,
-						ColMeta: []execute.ColMeta{
-							{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-							{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-							{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
-							{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
-						},
-						Data: [][]interface{}{
-							{execute.Time(0), 4.0, "a", "x"},
-							{execute.Time(100), 14.0, "a", "y"},
-						},
+			want: []*executetest.Block{
+				{
+					Bnds: execute.Bounds{
+						Start: 0,
+						Stop:  100,
 					},
-					{
-						Bnds: b,
-						ColMeta: []execute.ColMeta{
-							{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
-							{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
-							{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
-							{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
-						},
-						Data: [][]interface{}{
-							{execute.Time(0), 3.3, "b", "x"},
-							{execute.Time(100), 12.3, "b", "y"},
-						},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
 					},
-				}
+					Data: [][]interface{}{
+						{execute.Time(0), 4.0, "a", "x"},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 100,
+						Stop:  200,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
+					},
+					Data: [][]interface{}{
+						{execute.Time(100), 14.0, "a", "y"},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 0,
+						Stop:  100,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), 3.3, "b", "x"},
+					},
+				},
+				{
+					Bnds: execute.Bounds{
+						Start: 100,
+						Stop:  200,
+					},
+					ColMeta: []execute.ColMeta{
+						{Label: "_time", Type: execute.TTime, Kind: execute.TimeColKind},
+						{Label: "_value", Type: execute.TFloat, Kind: execute.ValueColKind},
+						{Label: "t1", Type: execute.TString, Kind: execute.TagColKind, Common: true},
+						{Label: "t2", Type: execute.TString, Kind: execute.TagColKind, Common: false},
+					},
+					Data: [][]interface{}{
+						{execute.Time(100), 12.3, "b", "y"},
+					},
+				},
 			},
 		},
 	}
@@ -777,7 +852,7 @@ func TestIndexSelector_Process(t *testing.T) {
 			c := execute.NewBlockBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
 
-			selector := execute.NewIndexSelectorTransformation(d, c, tc.bounds, new(functions.FirstSelector), tc.selectorConfig)
+			selector := execute.NewIndexSelectorTransformation(d, c, new(functions.FirstSelector), tc.selectorConfig)
 
 			parentID := executetest.RandomDatasetID()
 			for _, b := range tc.data {
@@ -786,14 +861,13 @@ func TestIndexSelector_Process(t *testing.T) {
 				}
 			}
 
-			want := tc.want(tc.bounds)
 			got := executetest.BlocksFromCache(c)
 
 			sort.Sort(executetest.SortedBlocks(got))
-			sort.Sort(executetest.SortedBlocks(want))
+			sort.Sort(executetest.SortedBlocks(tc.want))
 
-			if !cmp.Equal(want, got, cmpopts.EquateNaNs()) {
-				t.Errorf("unexpected blocks -want/+got\n%s", cmp.Diff(want, got))
+			if !cmp.Equal(tc.want, got, cmpopts.EquateNaNs()) {
+				t.Errorf("unexpected blocks -want/+got\n%s", cmp.Diff(tc.want, got))
 			}
 		})
 	}


### PR DESCRIPTION
Update the `window` function to unwindow data when no arguments are given.
