### PR TITLE
Repair the map function

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -74,15 +74,17 @@ func compile(n semantic.Node, builtIns Scope) (Evaluator, error) {
 		}, nil
 	case *semantic.ObjectExpression:
 		properties := make(map[string]Evaluator, len(n.Properties))
+		propertyTypes := make(map[string]semantic.Type, len(n.Properties))
 		for _, p := range n.Properties {
 			node, err := compile(p.Value, builtIns)
 			if err != nil {
 				return nil, err
 			}
 			properties[p.Key.Name] = node
+			propertyTypes[p.Key.Name] = node.Type()
 		}
 		return &objEvaluator{
-			t:          n.Type(),
+			t:          semantic.NewObjectType(propertyTypes),
 			properties: properties,
 		}, nil
 	case *semantic.IdentifierExpression:

--- a/query/execute/row_fn.go
+++ b/query/execute/row_fn.go
@@ -192,7 +192,7 @@ func (f *RowMapFn) Type() semantic.Type {
 	return f.preparedFn.Type()
 }
 
-func (f *RowMapFn) Eval(row int, rr RowReader) (*Record, error) {
+func (f *RowMapFn) Eval(row int, rr RowReader) (values.Object, error) {
 	v, err := f.rowFn.eval(row, rr)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ func (f *RowMapFn) Eval(row int, rr RowReader) (*Record, error) {
 		f.wrapObj.Set(DefaultValueColLabel, v)
 		return f.wrapObj, nil
 	}
-	return v.Object().(*Record), nil
+	return v.Object(), nil
 }
 
 func ValueForRow(i, j int, rr RowReader) values.Value {


### PR DESCRIPTION
The map function will now work correctly without panicking so queries
like this work correctly:

    from(db: "telegraf")
        |> range(start: -5m)
        |> filter(fn: (r) => r._measurement == "cpu" and r._field == "usage_user")
        |> group(by: ["_measurement"])
        |> mean()
        |> map(fn: (r) => {mean: r._value})

In this query, the map didn't work correctly because the object
expression did not update its reported set of types. It reported an
object type with the `mean` being an unknown type rather than evaluating
the type based on the variable declarations. This is now fixed.

This also fixes the implementation of map so it doesn't use a type
assertion that panics. It creates a record and then iterates over the
result to add it to that record so a map always returns an object type.